### PR TITLE
feat: add registry authentication support

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,99 @@
+# grekt CLI
+
+## Architectural Principles
+
+1. **Backend Agnosticism**: CLI doesn't know what's behind the API. Could be Supabase, custom, anything.
+2. **Token Semantics**: CLI only transports tokens. Backend decides permissions.
+3. **Lockfile Determinism**: `install` never rewrites `resolved`. Lockfile is snapshot.
+4. **Single Protocol**: CLI only speaks API REST with registry.
+
+## Sources
+
+| Source | Example | Auth |
+|--------|---------|------|
+| Registry | `@scope/name` | Token (optional for public) |
+| GitHub | `github:user/repo` | GITHUB_TOKEN (for private) |
+| GitLab | `gitlab:user/repo` | GITLAB_TOKEN (for private) |
+
+## Directory Structure
+
+```
+src/
+├── commands/               # CLI commands (Commander.js)
+│   ├── login.ts           # OAuth/token login
+│   ├── logout.ts          # Remove credentials
+│   ├── whoami.ts          # Show current user
+│   ├── add.ts             # Add artifact
+│   ├── install.ts         # Install from lockfile
+│   ├── publish.ts         # Publish to registry
+│   ├── deprecate.ts       # Mark version deprecated
+│   └── undeprecate.ts     # Remove deprecation
+├── lib/
+│   ├── registry-client.ts # API client for registry
+│   ├── registry.ts        # S3 legacy (backwards compat)
+│   ├── credentials.ts     # Token storage
+│   ├── config.ts          # grekt.yaml
+│   ├── lockfile.ts        # grekt.lock
+│   └── sources.ts         # Parse github:/gitlab:
+├── schemas/               # Zod schemas
+└── utils/                 # UI helpers
+```
+
+## Credentials
+
+```yaml
+# ~/.grekt/credentials.yaml
+default:
+  url: https://registry.grekt.com
+  token: grk_xxxxxxxxxxxx
+```
+
+**Priority**: `GREKT_TOKEN` (env) > `credentials.yaml`
+
+Token from ENV never persisted. `logout` only clears credentials.yaml.
+
+## Environment Variables
+
+- `GREKT_TOKEN` - Registry token (CI/CD, priority over file)
+- `GITHUB_TOKEN` - GitHub private repos
+- `GITLAB_TOKEN` - GitLab private repos
+
+## Command Patterns
+
+### Auth Required (publish, deprecate)
+```typescript
+const token = getRegistryToken()
+if (!token) {
+  error("Not logged in. Run 'grekt login' first.")
+  process.exit(1)
+}
+```
+
+### Informational (whoami) - always exit 0
+```typescript
+if (!token) {
+  log("Not logged in")
+  return  // exit 0, no error
+}
+```
+
+## Lockfile: source vs resolved
+
+- `source`: Original identifier (`@author/name`, `github:user/repo`)
+- `resolved`: **Exact URL** used to download. Immutable after write.
+
+`install` uses `resolved` directly without recalculation. This ensures deterministic installs.
+
+## S3 Legacy Mode
+
+Commands `publish`, `deprecate`, `undeprecate` support `--s3` flag for backwards compatibility with S3-compatible storage. This requires S3 credentials in `~/.grekt/credentials.yaml`:
+
+```yaml
+default:
+  type: s3
+  endpoint: https://...
+  accessKeyId: ...
+  secretAccessKey: ...
+  bucket: ...
+  publicUrl: https://... (optional)
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grekt",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "CLI for managing AI artifacts (agents, skills, commands)",
   "type": "module",
   "bin": {

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -273,6 +273,7 @@ export const addCommand = new Command("add")
       version: artifactInfo.manifest.version,
       integrity,
       source: source.raw,
+      resolved: downloadResult.resolved, // Full URL, immutable after write
       files: fileHashes,
       agent: selectedAgent,
       skills: selectedSkills,

--- a/src/commands/deprecate.ts
+++ b/src/commands/deprecate.ts
@@ -1,17 +1,35 @@
 import { Command } from "commander";
-import { getRegistryCredentials, getCredentialsFromEnv } from "#/lib/credentials";
+import { getRegistryCredentials, getCredentialsFromEnv, getRegistryToken } from "#/lib/credentials";
+import { createRegistryClient } from "#/lib/registry-client";
 import {
   getArtifactMetadata,
   saveArtifactMetadata,
   versionExists,
   deprecateVersion,
 } from "#/lib/metadata";
-import { success, error, info, log, spinner } from "#/utils/ui";
+import { success, error, info, log, colors, spinner } from "#/utils/ui";
 
+/**
+ * Parse "@author/name@version" format.
+ * Returns null if format is invalid.
+ */
 function parseArtifactVersion(input: string): { artifactId: string; version: string } | null {
-  const match = input.match(/^(@[^@]+)@(.+)$/);
-  if (!match) return null;
-  return { artifactId: match[1], version: match[2] };
+  // @scope/name@version (version required)
+  const ARTIFACT_AT_VERSION = /^(?<artifactId>@[^@]+)@(?<version>.+)$/;
+
+  const match = input.match(ARTIFACT_AT_VERSION);
+  if (!match?.groups?.artifactId || !match?.groups?.version) return null;
+
+  return {
+    artifactId: match.groups.artifactId,
+    version: match.groups.version,
+  };
+}
+
+interface DeprecateOptions {
+  message: string;
+  registry: string;
+  s3?: boolean;
 }
 
 export const deprecateCommand = new Command("deprecate")
@@ -19,7 +37,8 @@ export const deprecateCommand = new Command("deprecate")
   .argument("<artifact@version>", "Artifact and version to deprecate (e.g., @author/name@1.0.0)")
   .option("-m, --message <message>", "Deprecation message", "This version is deprecated")
   .option("-r, --registry <name>", "Registry name from credentials.yaml", "default")
-  .action(async (artifactVersion: string, options: { message: string; registry: string }) => {
+  .option("--s3", "Use S3-compatible storage (legacy mode)")
+  .action(async (artifactVersion: string, options: DeprecateOptions) => {
     const parsed = parseArtifactVersion(artifactVersion);
     if (!parsed) {
       error("Invalid format. Use: @author/name@version");
@@ -28,46 +47,87 @@ export const deprecateCommand = new Command("deprecate")
 
     const { artifactId, version } = parsed;
 
-    let credentials = getCredentialsFromEnv();
-    if (!credentials) {
-      credentials = getRegistryCredentials(options.registry);
+    if (options.s3) {
+      await deprecateS3(artifactId, version, options.message, options.registry);
+    } else {
+      await deprecateApi(artifactId, version, options.message);
     }
+  });
 
-    if (!credentials) {
-      error("No registry credentials found");
-      process.exit(1);
-    }
+/**
+ * Deprecate using the new API-based registry
+ */
+async function deprecateApi(artifactId: string, version: string, message: string): Promise<void> {
+  const token = getRegistryToken();
 
-    const spin = spinner("Checking artifact...");
-    spin.start();
+  if (!token) {
+    error("Not logged in");
+    info("Run 'grekt login' first");
+    log("");
+    log(colors.dim("For S3-compatible storage, use --s3 flag"));
+    process.exit(1);
+  }
 
-    const exists = await versionExists(credentials, artifactId, version);
-    if (!exists) {
-      spin.stop();
-      error(`Version ${version} does not exist for ${artifactId}`);
-      process.exit(1);
-    }
+  const client = createRegistryClient();
+  const spin = spinner("Deprecating version...");
+  spin.start();
 
-    const metadata = await getArtifactMetadata(credentials, artifactId);
-    if (!metadata) {
-      spin.stop();
-      error(`Metadata not found for ${artifactId}`);
-      process.exit(1);
-    }
-
-    if (metadata.deprecated[version]) {
-      spin.stop();
-      info(`Version ${version} is already deprecated`);
-      log(`  Message: ${metadata.deprecated[version]}`);
-      process.exit(0);
-    }
-
-    spin.text = "Updating metadata...";
-
-    const updated = deprecateVersion(metadata, version, options.message);
-    await saveArtifactMetadata(credentials, updated);
-
+  try {
+    await client.deprecate(artifactId, version, message);
     spin.stop();
     success(`Deprecated ${artifactId}@${version}`);
-    log(`  Message: ${options.message}`);
-  });
+    log(`  Message: ${message}`);
+  } catch (err) {
+    spin.stop();
+    error(err instanceof Error ? err.message : "Failed to deprecate");
+    process.exit(1);
+  }
+}
+
+/**
+ * Deprecate using S3-compatible storage (legacy mode)
+ */
+async function deprecateS3(artifactId: string, version: string, message: string, registryName: string): Promise<void> {
+  let credentials = getCredentialsFromEnv();
+  if (!credentials) {
+    credentials = getRegistryCredentials(registryName);
+  }
+
+  if (!credentials) {
+    error("No S3 credentials found");
+    process.exit(1);
+  }
+
+  const spin = spinner("Checking artifact...");
+  spin.start();
+
+  const exists = await versionExists(credentials, artifactId, version);
+  if (!exists) {
+    spin.stop();
+    error(`Version ${version} does not exist for ${artifactId}`);
+    process.exit(1);
+  }
+
+  const metadata = await getArtifactMetadata(credentials, artifactId);
+  if (!metadata) {
+    spin.stop();
+    error(`Metadata not found for ${artifactId}`);
+    process.exit(1);
+  }
+
+  if (metadata.deprecated[version]) {
+    spin.stop();
+    info(`Version ${version} is already deprecated`);
+    log(`  Message: ${metadata.deprecated[version]}`);
+    process.exit(0);
+  }
+
+  spin.text = "Updating metadata...";
+
+  const updated = deprecateVersion(metadata, version, message);
+  await saveArtifactMetadata(credentials, updated);
+
+  spin.stop();
+  success(`Deprecated ${artifactId}@${version}`);
+  log(`  Message: ${message}`);
+}

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,11 +1,41 @@
 import { Command } from "commander";
-import { existsSync, mkdirSync, rmSync } from "fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { execSync } from "child_process";
 import { isInitialized, getConfig } from "#/lib/config";
 import { getLockfile, lockfileExists } from "#/lib/lockfile";
 import { ARTIFACTS_DIR } from "#/lib/paths";
 import { parseSource, downloadFromSource } from "#/lib/sources";
 import { hashDirectory, verifyIntegrity } from "#/lib/integrity";
 import { success, error, info, warning, log, newline, colors, spinner } from "#/utils/ui";
+
+/**
+ * Download directly from a resolved URL
+ */
+async function downloadFromUrl(url: string, targetDir: string): Promise<boolean> {
+  try {
+    const response = await fetch(url, {
+      headers: { "User-Agent": "grekt-cli" },
+    });
+
+    if (!response.ok) {
+      return false;
+    }
+
+    const buffer = await response.arrayBuffer();
+    const tempTarball = `/tmp/grekt-${Date.now()}.tar.gz`;
+    writeFileSync(tempTarball, Buffer.from(buffer));
+
+    mkdirSync(targetDir, { recursive: true });
+    execSync(`tar -xzf ${tempTarball} -C ${targetDir} --strip-components=1`, {
+      stdio: "pipe",
+    });
+    execSync(`rm -f ${tempTarball}`, { stdio: "pipe" });
+
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 export const installCommand = new Command("install")
   .alias("i")
@@ -70,30 +100,37 @@ export const installCommand = new Command("install")
         rmSync(targetDir, { recursive: true, force: true });
       }
 
-      // Parse source for download
-      const sourceStr = entry.source || artifactId;
-      const source = parseSource(sourceStr);
-
       const spin = spinner(`Installing ${artifactId}@${entry.version}...`);
       spin.start();
 
-      // Download artifact from source
-      mkdirSync(targetDir, { recursive: true });
-      const downloadResult = await downloadFromSource(source, targetDir, projectRoot);
+      let downloadSuccess = false;
 
-      if (!downloadResult.success) {
+      // Use resolved URL if available (strict mode - no recalculation)
+      if (entry.resolved) {
+        mkdirSync(targetDir, { recursive: true });
+        downloadSuccess = await downloadFromUrl(entry.resolved, targetDir);
+      } else {
+        // Fallback for old lockfiles without resolved
+        const sourceStr = entry.source || artifactId;
+        const source = parseSource(sourceStr);
+        mkdirSync(targetDir, { recursive: true });
+        const downloadResult = await downloadFromSource(source, targetDir, projectRoot);
+        downloadSuccess = downloadResult.success;
+
+        // Show deprecation warning if applicable
+        if (downloadResult.deprecationMessage) {
+          spin.stop();
+          warning(`${artifactId}@${entry.version} is deprecated: ${downloadResult.deprecationMessage}`);
+          spin.start();
+        }
+      }
+
+      if (!downloadSuccess) {
         spin.stop();
         rmSync(targetDir, { recursive: true, force: true });
         error(`Failed to download ${artifactId}`);
         failed++;
         continue;
-      }
-
-      // Show deprecation warning if applicable
-      if (downloadResult.deprecationMessage) {
-        spin.stop();
-        warning(`${artifactId}@${entry.version} is deprecated: ${downloadResult.deprecationMessage}`);
-        spin.start();
       }
 
       // Verify integrity

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,0 +1,164 @@
+import { Command } from "commander";
+import { createServer, type Server } from "http";
+import { setRegistryToken } from "#/lib/credentials";
+import { DEFAULT_REGISTRY } from "#/lib/paths";
+import { success, error, info, log, spinner } from "#/utils/ui";
+
+const LOGIN_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Open a URL in the default browser
+ */
+function openBrowser(url: string): void {
+  const platform = process.platform;
+  let command: string;
+
+  if (platform === "darwin") {
+    command = `open "${url}"`;
+  } else if (platform === "win32") {
+    command = `start "" "${url}"`;
+  } else {
+    command = `xdg-open "${url}"`;
+  }
+
+  try {
+    const { execSync } = require("child_process");
+    execSync(command, { stdio: "ignore" });
+  } catch {
+    // If browser fails to open, user will need to copy the URL manually
+  }
+}
+
+/**
+ * OAuth login flow - one-shot ephemeral server
+ */
+async function oauthLogin(registryUrl: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let server: Server;
+    let timeoutId: NodeJS.Timeout;
+
+    const cleanup = () => {
+      clearTimeout(timeoutId);
+      server?.close();
+    };
+
+    server = createServer((req, res) => {
+      const url = new URL(req.url!, `http://localhost`);
+      const token = url.searchParams.get("token");
+      const errorParam = url.searchParams.get("error");
+
+      // Set CORS headers
+      res.setHeader("Content-Type", "text/html");
+
+      if (errorParam) {
+        res.statusCode = 400;
+        res.end(`
+          <!DOCTYPE html>
+          <html>
+            <head><title>Login Failed</title></head>
+            <body style="font-family: system-ui; padding: 40px; text-align: center;">
+              <h1>Login Failed</h1>
+              <p>${errorParam}</p>
+              <p>You can close this window.</p>
+            </body>
+          </html>
+        `);
+        cleanup();
+        reject(new Error(errorParam));
+        return;
+      }
+
+      if (token) {
+        res.statusCode = 200;
+        res.end(`
+          <!DOCTYPE html>
+          <html>
+            <head><title>Login Successful</title></head>
+            <body style="font-family: system-ui; padding: 40px; text-align: center;">
+              <h1>Login Successful</h1>
+              <p>You can close this window and return to the terminal.</p>
+            </body>
+          </html>
+        `);
+        cleanup();
+        resolve(token);
+        return;
+      }
+
+      // No token or error - invalid request
+      res.statusCode = 400;
+      res.end(`
+        <!DOCTYPE html>
+        <html>
+          <head><title>Invalid Request</title></head>
+          <body style="font-family: system-ui; padding: 40px; text-align: center;">
+            <h1>Invalid Request</h1>
+            <p>No token received.</p>
+          </body>
+        </html>
+      `);
+    });
+
+    // Bind explicitly to 127.0.0.1, never 0.0.0.0
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        cleanup();
+        reject(new Error("Failed to start local server"));
+        return;
+      }
+
+      const port = address.port;
+      const callbackUrl = `http://localhost:${port}/callback`;
+      const authUrl = `${registryUrl}/auth/cli?redirect=${encodeURIComponent(callbackUrl)}`;
+
+      log("");
+      info("Opening browser for authentication...");
+      log("");
+      log(`  If the browser doesn't open, visit:`);
+      log(`  ${authUrl}`);
+      log("");
+
+      openBrowser(authUrl);
+    });
+
+    // Timeout after 5 minutes
+    timeoutId = setTimeout(() => {
+      cleanup();
+      reject(new Error("Login timed out. Please try again."));
+    }, LOGIN_TIMEOUT_MS);
+
+    server.on("error", (err) => {
+      cleanup();
+      reject(err);
+    });
+  });
+}
+
+export const loginCommand = new Command("login")
+  .description("Log in to a grekt registry")
+  .option("-r, --registry <url>", "Registry URL", DEFAULT_REGISTRY)
+  .option("--token <token>", "Use token directly (for CI/CD)")
+  .action(async (options: { registry: string; token?: string }) => {
+    // CI/CD mode: validate and save token directly
+    if (options.token) {
+      setRegistryToken(options.token, options.registry);
+      success("Logged in");
+      return;
+    }
+
+    // OAuth mode: one-shot ephemeral flow
+    const spin = spinner("Waiting for authentication...");
+
+    try {
+      const token = await oauthLogin(options.registry);
+      spin.start();
+      spin.stop();
+      setRegistryToken(token, options.registry);
+      success("Logged in");
+    } catch (err) {
+      spin.stop();
+      error(err instanceof Error ? err.message : "Login failed");
+      process.exit(1);
+    }
+  });

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,0 +1,24 @@
+import { Command } from "commander";
+import { removeRegistryToken, getRegistryToken } from "#/lib/credentials";
+import { success, info } from "#/utils/ui";
+
+export const logoutCommand = new Command("logout")
+  .description("Log out from a grekt registry")
+  .action(() => {
+    const token = getRegistryToken();
+
+    if (!token) {
+      info("Not logged in");
+      return;
+    }
+
+    // Check if using env var
+    if (process.env.GREKT_TOKEN) {
+      info("Using GREKT_TOKEN environment variable");
+      info("Unset the environment variable to log out");
+      return;
+    }
+
+    removeRegistryToken();
+    success("Logged out");
+  });

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -4,7 +4,8 @@ import { execSync } from "child_process";
 import { existsSync, readFileSync, unlinkSync } from "fs";
 import { basename, dirname, join, resolve } from "path";
 import { parse } from "yaml";
-import { getRegistryCredentials, getCredentialsFromEnv, getCredentialsPath } from "#/lib/credentials";
+import { getRegistryCredentials, getCredentialsFromEnv, getCredentialsPath, getRegistryToken } from "#/lib/credentials";
+import { createRegistryClient } from "#/lib/registry-client";
 import {
   getArtifactMetadata,
   saveArtifactMetadata,
@@ -14,13 +15,21 @@ import {
 } from "#/lib/metadata";
 import { success, error, info, log, colors, spinner } from "#/utils/ui";
 
+interface PublishOptions {
+  registry: string;
+  local?: boolean;
+  output?: string;
+  s3?: boolean;
+}
+
 export const publishCommand = new Command("publish")
   .description("Publish an artifact to a registry")
   .argument("<path>", "Path to artifact directory")
   .option("-r, --registry <name>", "Registry name from credentials.yaml", "default")
   .option("--local", "Only create tarball locally (no upload)")
   .option("-o, --output <path>", "Output path for tarball (with --local)")
-  .action(async (artifactPath: string, options: { registry: string; local?: boolean; output?: string }) => {
+  .option("--s3", "Use S3-compatible storage (legacy mode)")
+  .action(async (artifactPath: string, options: PublishOptions) => {
     const fullPath = resolve(artifactPath);
 
     if (!existsSync(fullPath)) {
@@ -58,115 +67,197 @@ export const publishCommand = new Command("publish")
       return;
     }
 
-    // Get credentials (env vars take precedence, then credentials file)
-    let credentials = getCredentialsFromEnv();
-
-    if (!credentials) {
-      credentials = getRegistryCredentials(options.registry);
-    }
-
-    if (!credentials) {
-      unlinkSync(outputPath);
-      error("No registry credentials found");
-      log("");
-      info("Configure credentials in one of these ways:");
-      log("");
-      log(colors.dim("  1. Environment variables:"));
-      log("     GREKT_STORAGE_ENDPOINT=https://...");
-      log("     GREKT_STORAGE_ACCESS_KEY_ID=...");
-      log("     GREKT_STORAGE_SECRET_ACCESS_KEY=...");
-      log("     GREKT_STORAGE_BUCKET=...");
-      log("");
-      log(colors.dim(`  2. Credentials file (${getCredentialsPath()}):`));
-      log("     default:");
-      log("       type: s3");
-      log("       endpoint: https://...");
-      log("       accessKeyId: ...");
-      log("       secretAccessKey: ...");
-      log("       bucket: ...");
-      log("       publicUrl: https://... (optional)");
-      log("");
-      log(colors.dim("  3. Use --local to create tarball without uploading"));
-      process.exit(1);
-    }
-
-    // Check if version already exists
-    const checkSpin = spinner("Checking if version exists...");
-    checkSpin.start();
-
-    try {
-      const exists = await versionExists(credentials, artifactId, manifest.version);
-      checkSpin.stop();
-
-      if (exists) {
-        unlinkSync(outputPath);
-        error(`Version ${manifest.version} already exists for ${artifactId}`);
-        info("Bump the version in grekt.yaml and try again");
-        process.exit(1);
-      }
-    } catch (err) {
-      checkSpin.stop();
-      // If we can't check, continue anyway (might be a new artifact)
-    }
-
-    // Upload to S3-compatible storage
-    const spin = spinner("Uploading...");
-    spin.start();
-
-    const client = new S3Client({
-      region: "auto",
-      endpoint: credentials.endpoint,
-      credentials: {
-        accessKeyId: credentials.accessKeyId,
-        secretAccessKey: credentials.secretAccessKey,
-      },
-    });
-
-    const key = `artifacts/${artifactId}/${manifest.version}.tar.gz`;
-    const body = readFileSync(outputPath);
-
-    try {
-      await client.send(
-        new PutObjectCommand({
-          Bucket: credentials.bucket,
-          Key: key,
-          Body: body,
-          ContentType: "application/gzip",
-        })
-      );
-
-      spin.stop();
-      success(`Uploaded: ${key}`);
-
-      // Update metadata
-      const metaSpin = spinner("Updating metadata...");
-      metaSpin.start();
-
-      let metadata = await getArtifactMetadata(credentials, artifactId);
-      if (metadata) {
-        metadata = updateMetadataVersion(metadata, manifest.version);
-      } else {
-        metadata = createMetadata(artifactId, manifest.version);
-      }
-      await saveArtifactMetadata(credentials, metadata);
-
-      metaSpin.stop();
-      success("Metadata updated");
-
-      unlinkSync(outputPath);
-
-      log("");
-      success(`Published ${artifactId}@${manifest.version}`);
-
-      if (credentials.publicUrl) {
-        log(`  URL: ${credentials.publicUrl}/${key}`);
-      }
-
-      log(`\n  Install with: grekt add ${artifactId}@${manifest.version}\n`);
-    } catch (err) {
-      spin.stop();
-      unlinkSync(outputPath);
-      error(`Upload failed: ${err instanceof Error ? err.message : "Unknown error"}`);
-      process.exit(1);
+    // Determine publish mode
+    if (options.s3) {
+      await publishToS3(artifactId, manifest.version, outputPath, options.registry);
+    } else {
+      await publishToApi(artifactId, manifest.version, outputPath);
     }
   });
+
+/**
+ * Publish using the new API-based registry
+ */
+async function publishToApi(artifactId: string, version: string, tarballPath: string): Promise<void> {
+  const token = getRegistryToken();
+
+  if (!token) {
+    unlinkSync(tarballPath);
+    error("Not logged in");
+    info("Run 'grekt login' first");
+    log("");
+    log(colors.dim("For S3-compatible storage, use --s3 flag"));
+    process.exit(1);
+  }
+
+  const client = createRegistryClient();
+
+  // Check if version already exists
+  const checkSpin = spinner("Checking if version exists...");
+  checkSpin.start();
+
+  try {
+    const exists = await client.versionExists(artifactId, version);
+    checkSpin.stop();
+
+    if (exists) {
+      unlinkSync(tarballPath);
+      error(`Version ${version} already exists for ${artifactId}`);
+      info("Bump the version in grekt.yaml and try again");
+      process.exit(1);
+    }
+  } catch {
+    checkSpin.stop();
+    // If we can't check, continue anyway (might be a new artifact)
+  }
+
+  // Get upload URL from API
+  const spin = spinner("Requesting upload URL...");
+  spin.start();
+
+  try {
+    const { uploadUrl } = await client.publish(artifactId, version);
+    spin.text = "Uploading...";
+
+    // Upload tarball to signed URL
+    const body = readFileSync(tarballPath);
+    const uploadResponse = await fetch(uploadUrl, {
+      method: "PUT",
+      body,
+      headers: { "Content-Type": "application/gzip" },
+    });
+
+    if (!uploadResponse.ok) {
+      throw new Error(`Upload failed: ${uploadResponse.status}`);
+    }
+
+    spin.stop();
+    unlinkSync(tarballPath);
+
+    log("");
+    success(`Published ${artifactId}@${version}`);
+    log(`\n  Install with: grekt add ${artifactId}@${version}\n`);
+  } catch (err) {
+    spin.stop();
+    unlinkSync(tarballPath);
+    error(`Publish failed: ${err instanceof Error ? err.message : "Unknown error"}`);
+    process.exit(1);
+  }
+}
+
+/**
+ * Publish using S3-compatible storage (legacy mode)
+ */
+async function publishToS3(artifactId: string, version: string, tarballPath: string, registryName: string): Promise<void> {
+  // Get credentials (env vars take precedence, then credentials file)
+  let credentials = getCredentialsFromEnv();
+
+  if (!credentials) {
+    credentials = getRegistryCredentials(registryName);
+  }
+
+  if (!credentials) {
+    unlinkSync(tarballPath);
+    error("No S3 credentials found");
+    log("");
+    info("Configure credentials in one of these ways:");
+    log("");
+    log(colors.dim("  1. Environment variables:"));
+    log("     GREKT_STORAGE_ENDPOINT=https://...");
+    log("     GREKT_STORAGE_ACCESS_KEY_ID=...");
+    log("     GREKT_STORAGE_SECRET_ACCESS_KEY=...");
+    log("     GREKT_STORAGE_BUCKET=...");
+    log("");
+    log(colors.dim(`  2. Credentials file (${getCredentialsPath()}):`));
+    log("     default:");
+    log("       type: s3");
+    log("       endpoint: https://...");
+    log("       accessKeyId: ...");
+    log("       secretAccessKey: ...");
+    log("       bucket: ...");
+    log("       publicUrl: https://... (optional)");
+    log("");
+    log(colors.dim("  3. Use --local to create tarball without uploading"));
+    process.exit(1);
+  }
+
+  // Check if version already exists
+  const checkSpin = spinner("Checking if version exists...");
+  checkSpin.start();
+
+  try {
+    const exists = await versionExists(credentials, artifactId, version);
+    checkSpin.stop();
+
+    if (exists) {
+      unlinkSync(tarballPath);
+      error(`Version ${version} already exists for ${artifactId}`);
+      info("Bump the version in grekt.yaml and try again");
+      process.exit(1);
+    }
+  } catch {
+    checkSpin.stop();
+    // If we can't check, continue anyway (might be a new artifact)
+  }
+
+  // Upload to S3-compatible storage
+  const spin = spinner("Uploading...");
+  spin.start();
+
+  const client = new S3Client({
+    region: "auto",
+    endpoint: credentials.endpoint,
+    credentials: {
+      accessKeyId: credentials.accessKeyId,
+      secretAccessKey: credentials.secretAccessKey,
+    },
+  });
+
+  const key = `artifacts/${artifactId}/${version}.tar.gz`;
+  const body = readFileSync(tarballPath);
+
+  try {
+    await client.send(
+      new PutObjectCommand({
+        Bucket: credentials.bucket,
+        Key: key,
+        Body: body,
+        ContentType: "application/gzip",
+      })
+    );
+
+    spin.stop();
+    success(`Uploaded: ${key}`);
+
+    // Update metadata
+    const metaSpin = spinner("Updating metadata...");
+    metaSpin.start();
+
+    let metadata = await getArtifactMetadata(credentials, artifactId);
+    if (metadata) {
+      metadata = updateMetadataVersion(metadata, version);
+    } else {
+      metadata = createMetadata(artifactId, version);
+    }
+    await saveArtifactMetadata(credentials, metadata);
+
+    metaSpin.stop();
+    success("Metadata updated");
+
+    unlinkSync(tarballPath);
+
+    log("");
+    success(`Published ${artifactId}@${version}`);
+
+    if (credentials.publicUrl) {
+      log(`  URL: ${credentials.publicUrl}/${key}`);
+    }
+
+    log(`\n  Install with: grekt add ${artifactId}@${version}\n`);
+  } catch (err) {
+    spin.stop();
+    unlinkSync(tarballPath);
+    error(`Upload failed: ${err instanceof Error ? err.message : "Unknown error"}`);
+    process.exit(1);
+  }
+}

--- a/src/commands/undeprecate.ts
+++ b/src/commands/undeprecate.ts
@@ -1,23 +1,41 @@
 import { Command } from "commander";
-import { getRegistryCredentials, getCredentialsFromEnv } from "#/lib/credentials";
+import { getRegistryCredentials, getCredentialsFromEnv, getRegistryToken } from "#/lib/credentials";
+import { createRegistryClient } from "#/lib/registry-client";
 import {
   getArtifactMetadata,
   saveArtifactMetadata,
   undeprecateVersion,
 } from "#/lib/metadata";
-import { success, error, info, spinner } from "#/utils/ui";
+import { success, error, info, log, colors, spinner } from "#/utils/ui";
 
+/**
+ * Parse "@author/name@version" format.
+ * Returns null if format is invalid.
+ */
 function parseArtifactVersion(input: string): { artifactId: string; version: string } | null {
-  const match = input.match(/^(@[^@]+)@(.+)$/);
-  if (!match) return null;
-  return { artifactId: match[1], version: match[2] };
+  // @scope/name@version (version required)
+  const ARTIFACT_AT_VERSION = /^(?<artifactId>@[^@]+)@(?<version>.+)$/;
+
+  const match = input.match(ARTIFACT_AT_VERSION);
+  if (!match?.groups?.artifactId || !match?.groups?.version) return null;
+
+  return {
+    artifactId: match.groups.artifactId,
+    version: match.groups.version,
+  };
+}
+
+interface UndeprecateOptions {
+  registry: string;
+  s3?: boolean;
 }
 
 export const undeprecateCommand = new Command("undeprecate")
   .description("Remove deprecation from an artifact version")
   .argument("<artifact@version>", "Artifact and version to undeprecate (e.g., @author/name@1.0.0)")
   .option("-r, --registry <name>", "Registry name from credentials.yaml", "default")
-  .action(async (artifactVersion: string, options: { registry: string }) => {
+  .option("--s3", "Use S3-compatible storage (legacy mode)")
+  .action(async (artifactVersion: string, options: UndeprecateOptions) => {
     const parsed = parseArtifactVersion(artifactVersion);
     if (!parsed) {
       error("Invalid format. Use: @author/name@version");
@@ -26,37 +44,77 @@ export const undeprecateCommand = new Command("undeprecate")
 
     const { artifactId, version } = parsed;
 
-    let credentials = getCredentialsFromEnv();
-    if (!credentials) {
-      credentials = getRegistryCredentials(options.registry);
+    if (options.s3) {
+      await undeprecateS3(artifactId, version, options.registry);
+    } else {
+      await undeprecateApi(artifactId, version);
     }
+  });
 
-    if (!credentials) {
-      error("No registry credentials found");
-      process.exit(1);
-    }
+/**
+ * Undeprecate using the new API-based registry
+ */
+async function undeprecateApi(artifactId: string, version: string): Promise<void> {
+  const token = getRegistryToken();
 
-    const spin = spinner("Checking artifact...");
-    spin.start();
+  if (!token) {
+    error("Not logged in");
+    info("Run 'grekt login' first");
+    log("");
+    log(colors.dim("For S3-compatible storage, use --s3 flag"));
+    process.exit(1);
+  }
 
-    const metadata = await getArtifactMetadata(credentials, artifactId);
-    if (!metadata) {
-      spin.stop();
-      error(`Metadata not found for ${artifactId}`);
-      process.exit(1);
-    }
+  const client = createRegistryClient();
+  const spin = spinner("Removing deprecation...");
+  spin.start();
 
-    if (!metadata.deprecated[version]) {
-      spin.stop();
-      info(`Version ${version} is not deprecated`);
-      process.exit(0);
-    }
-
-    spin.text = "Updating metadata...";
-
-    const updated = undeprecateVersion(metadata, version);
-    await saveArtifactMetadata(credentials, updated);
-
+  try {
+    await client.undeprecate(artifactId, version);
     spin.stop();
     success(`Removed deprecation from ${artifactId}@${version}`);
-  });
+  } catch (err) {
+    spin.stop();
+    error(err instanceof Error ? err.message : "Failed to undeprecate");
+    process.exit(1);
+  }
+}
+
+/**
+ * Undeprecate using S3-compatible storage (legacy mode)
+ */
+async function undeprecateS3(artifactId: string, version: string, registryName: string): Promise<void> {
+  let credentials = getCredentialsFromEnv();
+  if (!credentials) {
+    credentials = getRegistryCredentials(registryName);
+  }
+
+  if (!credentials) {
+    error("No S3 credentials found");
+    process.exit(1);
+  }
+
+  const spin = spinner("Checking artifact...");
+  spin.start();
+
+  const metadata = await getArtifactMetadata(credentials, artifactId);
+  if (!metadata) {
+    spin.stop();
+    error(`Metadata not found for ${artifactId}`);
+    process.exit(1);
+  }
+
+  if (!metadata.deprecated[version]) {
+    spin.stop();
+    info(`Version ${version} is not deprecated`);
+    process.exit(0);
+  }
+
+  spin.text = "Updating metadata...";
+
+  const updated = undeprecateVersion(metadata, version);
+  await saveArtifactMetadata(credentials, updated);
+
+  spin.stop();
+  success(`Removed deprecation from ${artifactId}@${version}`);
+}

--- a/src/commands/versions.ts
+++ b/src/commands/versions.ts
@@ -51,10 +51,10 @@ export const versionsCommand = new Command("versions")
 
       let line = `  ${version}`;
       if (isLatest) {
-        line += colors.green(" (latest)");
+        line += colors.success(" (latest)");
       }
       if (deprecationMsg) {
-        line += colors.yellow(` ⚠ deprecated: ${deprecationMsg}`);
+        line += colors.warning(` ⚠ deprecated: ${deprecationMsg}`);
       }
 
       log(line);

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -1,0 +1,41 @@
+import { Command } from "commander";
+import { getRegistryToken, getRegistryUrl } from "#/lib/credentials";
+import { createRegistryClient } from "#/lib/registry-client";
+import { log, colors, spinner } from "#/utils/ui";
+
+export const whoamiCommand = new Command("whoami")
+  .description("Show current user")
+  .action(async () => {
+    const token = getRegistryToken();
+    const registryUrl = getRegistryUrl();
+
+    if (!token) {
+      log("Not logged in");
+      log(colors.dim(`Registry: ${registryUrl}`));
+      return; // Exit 0, informational
+    }
+
+    const spin = spinner("Checking...");
+    spin.start();
+
+    const client = createRegistryClient();
+
+    try {
+      const user = await client.whoami();
+      spin.stop();
+
+      if (user) {
+        log(`Logged in as ${colors.highlight(user.email)}`);
+        log(colors.dim(`Registry: ${registryUrl}`));
+      } else {
+        log("Not logged in");
+        log(colors.dim(`Registry: ${registryUrl}`));
+      }
+    } catch {
+      spin.stop();
+      // Token invalid/expired = not logged in
+      log("Not logged in");
+      log(colors.dim(`Registry: ${registryUrl}`));
+    }
+    // Always exit 0
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,14 +14,24 @@ import { deprecateCommand } from "#/commands/deprecate";
 import { undeprecateCommand } from "#/commands/undeprecate";
 import { infoCommand } from "#/commands/info";
 import { versionsCommand } from "#/commands/versions";
+import { loginCommand } from "#/commands/login";
+import { logoutCommand } from "#/commands/logout";
+import { whoamiCommand } from "#/commands/whoami";
+import pkg from "../package.json";
 
 const program = new Command();
 
 program
-  .name("grekt")
-  .description("CLI for managing AI artifacts (agents, skills, commands)")
-  .version("0.1.0");
+  .name(pkg.name)
+  .description(pkg.description)
+  .version(pkg.version);
 
+// Auth commands
+program.addCommand(loginCommand);
+program.addCommand(logoutCommand);
+program.addCommand(whoamiCommand);
+
+// Project commands
 program.addCommand(initCommand);
 program.addCommand(configCommand);
 program.addCommand(syncCommand);
@@ -30,6 +40,8 @@ program.addCommand(addCommand);
 program.addCommand(installCommand);
 program.addCommand(checkCommand);
 program.addCommand(removeCommand);
+
+// Registry commands
 program.addCommand(publishCommand);
 program.addCommand(deprecateCommand);
 program.addCommand(undeprecateCommand);

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -2,7 +2,9 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
 import { parse, stringify } from "yaml";
-import { CredentialsSchema, type Credentials, type S3Credentials, type TokenCredentials } from "#/schemas/index";
+import { CredentialsSchema, type Credentials, type S3Credentials, type TokenCredentials, type ApiCredentials } from "#/schemas/index";
+import { getConfig } from "#/lib/config";
+import { DEFAULT_REGISTRY } from "#/lib/paths";
 
 const GREKT_HOME = join(homedir(), ".grekt");
 const CREDENTIALS_FILE = join(GREKT_HOME, "credentials.yaml");
@@ -98,4 +100,79 @@ export function getCredentialsFromEnv(): S3Credentials | undefined {
     bucket,
     publicUrl,
   };
+}
+
+// ============================================================================
+// Registry Token Management (for API-based registries)
+// ============================================================================
+
+/**
+ * Get registry token. Priority: GREKT_TOKEN env > credentials.yaml
+ */
+export function getRegistryToken(): string | undefined {
+  // 1. Env var (CI/CD) - never persisted, logout doesn't affect it
+  const envToken = process.env.GREKT_TOKEN;
+  if (envToken) return envToken;
+
+  // 2. Credentials file
+  const credentials = getCredentials();
+  const defaultCred = credentials.default;
+  if (defaultCred && "url" in defaultCred && "token" in defaultCred) {
+    return defaultCred.token;
+  }
+
+  return undefined;
+}
+
+/**
+ * Save registry token (only for login, not for env)
+ */
+export function setRegistryToken(token: string, url: string): void {
+  const credentials = getCredentials();
+  credentials.default = { url, token } as ApiCredentials;
+  saveCredentials(credentials);
+}
+
+/**
+ * Remove registry token (only affects credentials.yaml, not env)
+ */
+export function removeRegistryToken(): void {
+  const credentials = getCredentials();
+  delete credentials.default;
+  saveCredentials(credentials);
+}
+
+/**
+ * Get registry URL. Priority: project config > credentials.yaml > default
+ */
+export function getRegistryUrl(projectRoot?: string): string {
+  // 1. Project config
+  try {
+    const config = getConfig(projectRoot);
+    if (config.registry) return config.registry;
+  } catch {
+    // Config might not exist (e.g., global commands like whoami)
+  }
+
+  // 2. Credentials file
+  const credentials = getCredentials();
+  const defaultCred = credentials.default;
+  if (defaultCred && "url" in defaultCred) {
+    return defaultCred.url;
+  }
+
+  // 3. Default
+  return DEFAULT_REGISTRY;
+}
+
+/**
+ * Get API credentials for the default registry
+ */
+export function getApiCredentials(): ApiCredentials | undefined {
+  const credentials = getCredentials();
+  const defaultCred = credentials.default;
+  if (defaultCred && "url" in defaultCred && "token" in defaultCred) {
+    return defaultCred as ApiCredentials;
+  }
+  return undefined;
 }

--- a/src/lib/registry-client.ts
+++ b/src/lib/registry-client.ts
@@ -1,0 +1,213 @@
+import { mkdirSync, writeFileSync } from "fs";
+import { execSync } from "child_process";
+import type { ArtifactMetadata } from "#/schemas/index";
+import { getRegistryToken, getRegistryUrl } from "#/lib/credentials";
+
+export interface VersionInfo {
+  version: string;
+  deprecated?: string;
+  createdAt: string;
+}
+
+export interface DownloadResult {
+  success: boolean;
+  version?: string;
+  resolved?: string;
+  deprecationMessage?: string;
+}
+
+export interface PublishResult {
+  uploadUrl: string;
+}
+
+export interface WhoamiResult {
+  email: string;
+}
+
+/**
+ * Registry API client. Backend-agnostic - only speaks REST.
+ */
+export class RegistryClient {
+  constructor(
+    private baseUrl: string,
+    private getToken: () => string | undefined
+  ) {}
+
+  private async fetch(path: string, options?: RequestInit): Promise<Response> {
+    const token = this.getToken();
+    const headers: Record<string, string> = {
+      "User-Agent": "grekt-cli",
+      ...(options?.headers as Record<string, string>),
+    };
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+    }
+    return fetch(`${this.baseUrl}${path}`, { ...options, headers });
+  }
+
+  // ============================================================================
+  // Public endpoints (no auth required)
+  // ============================================================================
+
+  /**
+   * Get artifact metadata
+   */
+  async getArtifact(artifactId: string): Promise<ArtifactMetadata | null> {
+    try {
+      const response = await this.fetch(`/artifacts/${encodeURIComponent(artifactId)}`);
+      if (!response.ok) return null;
+      return await response.json();
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Get all versions for an artifact
+   */
+  async getVersions(artifactId: string): Promise<VersionInfo[]> {
+    try {
+      const response = await this.fetch(`/artifacts/${encodeURIComponent(artifactId)}/versions`);
+      if (!response.ok) return [];
+      return await response.json();
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Download artifact tarball
+   */
+  async download(artifactId: string, version: string | undefined, targetDir: string): Promise<DownloadResult> {
+    try {
+      // First, get metadata to resolve version
+      const metadata = await this.getArtifact(artifactId);
+      if (!metadata) {
+        return { success: false };
+      }
+
+      const resolvedVersion = version || metadata.latest;
+      const tarballUrl = `${this.baseUrl}/artifacts/${encodeURIComponent(artifactId)}/${resolvedVersion}.tar.gz`;
+      const deprecationMessage = metadata.deprecated[resolvedVersion];
+
+      const response = await fetch(tarballUrl, {
+        headers: { "User-Agent": "grekt-cli" },
+      });
+
+      if (!response.ok) {
+        return { success: false };
+      }
+
+      const buffer = await response.arrayBuffer();
+      const tempTarball = `/tmp/grekt-${Date.now()}.tar.gz`;
+      writeFileSync(tempTarball, Buffer.from(buffer));
+
+      mkdirSync(targetDir, { recursive: true });
+      execSync(`tar -xzf ${tempTarball} -C ${targetDir} --strip-components=1`, {
+        stdio: "pipe",
+      });
+      execSync(`rm -f ${tempTarball}`, { stdio: "pipe" });
+
+      return {
+        success: true,
+        version: resolvedVersion,
+        resolved: tarballUrl,
+        deprecationMessage,
+      };
+    } catch {
+      return { success: false };
+    }
+  }
+
+  // ============================================================================
+  // Authenticated endpoints (token required)
+  // ============================================================================
+
+  /**
+   * Get current user info. Returns null if not authenticated.
+   */
+  async whoami(): Promise<WhoamiResult | null> {
+    try {
+      const response = await this.fetch("/auth/whoami");
+      if (!response.ok) return null;
+      return await response.json();
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Request upload URL for publishing
+   */
+  async publish(artifactId: string, version: string): Promise<PublishResult> {
+    const response = await this.fetch(`/artifacts/${encodeURIComponent(artifactId)}/versions/${version}/upload`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(error || `Failed to get upload URL: ${response.status}`);
+    }
+
+    return await response.json();
+  }
+
+  /**
+   * Deprecate a version
+   */
+  async deprecate(artifactId: string, version: string, message: string): Promise<void> {
+    const response = await this.fetch(
+      `/artifacts/${encodeURIComponent(artifactId)}/versions/${version}/deprecate`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message }),
+      }
+    );
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(error || `Failed to deprecate: ${response.status}`);
+    }
+  }
+
+  /**
+   * Remove deprecation from a version
+   */
+  async undeprecate(artifactId: string, version: string): Promise<void> {
+    const response = await this.fetch(
+      `/artifacts/${encodeURIComponent(artifactId)}/versions/${version}/undeprecate`,
+      {
+        method: "POST",
+      }
+    );
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(error || `Failed to undeprecate: ${response.status}`);
+    }
+  }
+
+  /**
+   * Check if a version exists
+   */
+  async versionExists(artifactId: string, version: string): Promise<boolean> {
+    try {
+      const response = await this.fetch(
+        `/artifacts/${encodeURIComponent(artifactId)}/versions/${version}`
+      );
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+}
+
+/**
+ * Factory to create a registry client with default configuration
+ */
+export function createRegistryClient(projectRoot?: string): RegistryClient {
+  const url = getRegistryUrl(projectRoot);
+  return new RegistryClient(url, () => getRegistryToken());
+}

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -13,6 +13,7 @@ export function getRegistryUrl(projectRoot: string = process.cwd()): string {
 export interface DownloadResult {
   success: boolean;
   version?: string;
+  resolved?: string;
   deprecationMessage?: string;
 }
 
@@ -32,11 +33,24 @@ export async function fetchRegistryMetadata(
   }
 }
 
+/**
+ * Parse artifact source string into ID and optional version.
+ * Examples:
+ *   "@author/name"       → { artifactId: "@author/name" }
+ *   "@author/name@1.0.0" → { artifactId: "@author/name", version: "1.0.0" }
+ */
 export function parseArtifactWithVersion(source: string): { artifactId: string; version?: string } {
-  const match = source.match(/^(@[^@]+)(?:@(.+))?$/);
-  if (match) {
-    return { artifactId: match[1], version: match[2] };
+  // @scope/name optionally followed by @version
+  const ARTIFACT_WITH_VERSION = /^(?<artifactId>@[^@]+)(?:@(?<version>.+))?$/;
+
+  const match = source.match(ARTIFACT_WITH_VERSION);
+  if (match?.groups?.artifactId) {
+    return {
+      artifactId: match.groups.artifactId,
+      version: match.groups.version,
+    };
   }
+
   return { artifactId: source };
 }
 
@@ -73,7 +87,7 @@ export async function downloadFromRegistry(
     });
     execSync(`rm -f ${tempTarball}`, { stdio: "pipe" });
 
-    return { success: true, version, deprecationMessage };
+    return { success: true, version, resolved: tarballUrl, deprecationMessage };
   } catch {
     return { success: false };
   }

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -67,10 +67,18 @@ export const TokenCredentialsSchema = z.object({
 });
 export type TokenCredentials = z.infer<typeof TokenCredentialsSchema>;
 
-// Registry credentials - can be S3 or token-based
+// API registry credentials (url + token)
+export const ApiCredentialsSchema = z.object({
+  url: z.string(),
+  token: z.string(),
+});
+export type ApiCredentials = z.infer<typeof ApiCredentialsSchema>;
+
+// Registry credentials - can be S3, token-based, or API-based
 export const RegistryCredentialsSchema = z.union([
   S3CredentialsSchema,
   TokenCredentialsSchema,
+  ApiCredentialsSchema,
 ]);
 export type RegistryCredentials = z.infer<typeof RegistryCredentialsSchema>;
 
@@ -85,6 +93,7 @@ export const LockfileEntrySchema = z.object({
   version: z.string(),
   integrity: z.string(), // SHA256 hash of entire artifact
   source: z.string().optional(),
+  resolved: z.string().optional(), // Full URL, IMMUTABLE after write
   files: z.record(z.string(), z.string()).default({}), // per-file hashes: { "agent.md": "sha256:abc..." }
   // Component paths (where to find agents/skills/commands in the artifact)
   agent: z.string().optional(), // relative path to agent.md if exists


### PR DESCRIPTION
New commands:
- login: OAuth browser flow + CI/CD token support
- logout: Remove stored credentials
- whoami: Show current authenticated user

New features:
- Registry API client (registry-client.ts)
- Token management in credentials.ts
- resolved field in lockfile for deterministic installs
- API mode as default for publish/deprecate/undeprecate
- --s3 flag for legacy S3 storage

Updated commands:
- add: Saves resolved URL in lockfile
- install: Uses resolved URL directly (no recalculation)
- publish: API mode default, --s3 for legacy
- deprecate/undeprecate: API mode default, --s3 for legacy

Breaking changes:
- publish/deprecate/undeprecate now require login (use --s3 for old behavior)

Bump version to 0.2.0