### PR TITLE
refactor: extract modules for better separation of concerns

### DIFF
--- a/src/artifact/artifact.ts
+++ b/src/artifact/artifact.ts
@@ -4,3 +4,6 @@ export * from "./integrity/integrity";
 export * from "./lockfile/lockfile";
 export * from "./check/check";
 export * from "./frontmatter/frontmatter";
+export * from "./naming/naming";
+export * from "./selector/selector";
+export * from "./component-manager/component-manager";

--- a/src/artifact/component-manager/component-manager.test.ts
+++ b/src/artifact/component-manager/component-manager.test.ts
@@ -1,0 +1,12 @@
+import { describe, test } from "bun:test";
+
+describe("component-manager", () => {
+  test.todo("removeUnselectedFiles removes agent when not selected");
+  test.todo("removeUnselectedFiles removes skills when not selected");
+  test.todo("removeUnselectedFiles removes commands when not selected");
+  test.todo("removeUnselectedFiles keeps selected components");
+  test.todo("cleanEmptyDirs removes empty subdirectories");
+  test.todo("cleanEmptyDirs keeps non-empty directories");
+  test.todo("removeIfEmpty removes empty directory");
+  test.todo("removeIfEmpty does nothing for non-empty directory");
+});

--- a/src/artifact/component-manager/component-manager.ts
+++ b/src/artifact/component-manager/component-manager.ts
@@ -1,0 +1,79 @@
+import { existsSync, unlinkSync, readdirSync, rmSync } from "fs";
+import { join } from "path";
+import type { ArtifactInfo } from "#/artifact/scanner/scanner";
+import type { ComponentSelection } from "#/artifact/selector/selector";
+
+/**
+ * Remove unselected component files from artifact directory.
+ * This is used when a user chooses to install only specific components.
+ */
+export function removeUnselectedFiles(
+  artifactDir: string,
+  artifactInfo: ArtifactInfo,
+  selection: ComponentSelection
+): void {
+  // Remove unselected agent
+  if (artifactInfo.agent && !selection.agent) {
+    const agentPath = join(artifactDir, artifactInfo.agent.path);
+    if (existsSync(agentPath)) {
+      unlinkSync(agentPath);
+    }
+  }
+
+  // Remove unselected skills
+  for (const skill of artifactInfo.skills) {
+    if (!selection.skills.includes(skill.path)) {
+      const skillPath = join(artifactDir, skill.path);
+      if (existsSync(skillPath)) {
+        unlinkSync(skillPath);
+      }
+    }
+  }
+
+  // Remove unselected commands
+  for (const cmd of artifactInfo.commands) {
+    if (!selection.commands.includes(cmd.path)) {
+      const cmdPath = join(artifactDir, cmd.path);
+      if (existsSync(cmdPath)) {
+        unlinkSync(cmdPath);
+      }
+    }
+  }
+
+  // Clean up empty directories
+  cleanEmptyDirs(artifactDir);
+}
+
+/**
+ * Recursively remove empty directories within a directory.
+ */
+export function cleanEmptyDirs(dir: string): void {
+  const entries = readdirSync(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      const subdir = join(dir, entry.name);
+      cleanEmptyDirs(subdir);
+
+      // Check if directory is now empty
+      const remaining = readdirSync(subdir);
+      if (remaining.length === 0) {
+        rmSync(subdir);
+      }
+    }
+  }
+}
+
+/**
+ * Remove a single directory if it's empty.
+ */
+export function removeIfEmpty(dir: string): boolean {
+  if (existsSync(dir)) {
+    const files = readdirSync(dir);
+    if (files.length === 0) {
+      rmSync(dir, { recursive: true });
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/artifact/integrity/integrity.ts
+++ b/src/artifact/integrity/integrity.ts
@@ -125,19 +125,5 @@ export function getDirectorySize(dir: string): number {
   return totalSize;
 }
 
-/**
- * Format bytes to human readable string
- */
-export function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
-
-/**
- * Estimate tokens from bytes (rough approximation)
- */
-export function estimateTokens(bytes: number): number {
-  // ~4 chars per token, ~1 byte per char for ASCII
-  return Math.round(bytes / 4);
-}
+// Re-export formatters for backwards compatibility
+export { formatBytes, estimateTokens } from "#/shared/formatters/formatters";

--- a/src/artifact/naming/naming.test.ts
+++ b/src/artifact/naming/naming.test.ts
@@ -1,0 +1,9 @@
+import { describe, test } from "bun:test";
+
+describe("naming", () => {
+  test.todo("getSafeFilename removes @ and replaces / with -");
+  test.todo("getSafeFilename extracts basename from filepath");
+  test.todo("getSafeFilename handles nested paths");
+  test.todo("toSafeName converts @scope/name to scope-name");
+  test.todo("toSafeName handles unscoped names");
+});

--- a/src/artifact/naming/naming.ts
+++ b/src/artifact/naming/naming.ts
@@ -1,0 +1,24 @@
+import { basename } from "path";
+
+/**
+ * Create a namespaced filename to avoid collisions between artifacts.
+ * Used when syncing artifacts to target directories.
+ *
+ * @example getSafeFilename("@grekt/analyzer", "skills/analyze.md") → "grekt-analyzer_analyze.md"
+ * @example getSafeFilename("my-artifact", "agent.md") → "my-artifact_agent.md"
+ */
+export function getSafeFilename(artifactId: string, filepath: string): string {
+  const safeName = artifactId.replace("@", "").replace("/", "-");
+  const filename = basename(filepath);
+  return `${safeName}_${filename}`;
+}
+
+/**
+ * Convert artifact ID to safe directory/file name format.
+ * Removes @ prefix and replaces / with -
+ *
+ * @example toSafeName("@grekt/analyzer") → "grekt-analyzer"
+ */
+export function toSafeName(artifactId: string): string {
+  return artifactId.replace("@", "").replace("/", "-");
+}

--- a/src/artifact/selector/selector.test.ts
+++ b/src/artifact/selector/selector.test.ts
@@ -1,0 +1,10 @@
+import { describe, test } from "bun:test";
+
+describe("selector", () => {
+  test.todo("selectComponents returns all components when all selected");
+  test.todo("selectComponents returns partial selection");
+  test.todo("isFullSelection returns true when all components selected");
+  test.todo("isFullSelection returns false for partial selection");
+  test.todo("isEmptySelection returns true when nothing selected");
+  test.todo("isEmptySelection returns false when something selected");
+});

--- a/src/artifact/selector/selector.ts
+++ b/src/artifact/selector/selector.ts
@@ -1,0 +1,83 @@
+import { checkbox } from "@inquirer/prompts";
+import type { ArtifactInfo } from "#/artifact/scanner/scanner";
+
+/**
+ * Represents the user's selection of artifact components.
+ */
+export interface ComponentSelection {
+  agent: string | undefined;
+  skills: string[];
+  commands: string[];
+}
+
+/**
+ * Prompt user to select which components to install from an artifact.
+ * Returns the paths of selected components.
+ */
+export async function selectComponents(artifactInfo: ArtifactInfo): Promise<ComponentSelection> {
+  const choices: Array<{ name: string; value: { type: string; path: string }; checked: boolean }> = [];
+
+  if (artifactInfo.agent) {
+    choices.push({
+      name: `agent: ${artifactInfo.agent.parsed.frontmatter.name}`,
+      value: { type: "agent", path: artifactInfo.agent.path },
+      checked: true,
+    });
+  }
+
+  for (const skill of artifactInfo.skills) {
+    choices.push({
+      name: `skill: ${skill.parsed.frontmatter.name}`,
+      value: { type: "skill", path: skill.path },
+      checked: true,
+    });
+  }
+
+  for (const cmd of artifactInfo.commands) {
+    choices.push({
+      name: `command: ${cmd.parsed.frontmatter.name}`,
+      value: { type: "command", path: cmd.path },
+      checked: true,
+    });
+  }
+
+  const selected = await checkbox({
+    message: "Select components to install:",
+    choices,
+  });
+
+  const result: ComponentSelection = {
+    agent: undefined,
+    skills: [],
+    commands: [],
+  };
+
+  for (const item of selected) {
+    if (item.type === "agent") {
+      result.agent = item.path;
+    } else if (item.type === "skill") {
+      result.skills.push(item.path);
+    } else if (item.type === "command") {
+      result.commands.push(item.path);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Check if all components in the artifact were selected.
+ */
+export function isFullSelection(artifactInfo: ArtifactInfo, selection: ComponentSelection): boolean {
+  const allAgent = artifactInfo.agent ? selection.agent === artifactInfo.agent.path : true;
+  const allSkills = selection.skills.length === artifactInfo.skills.length;
+  const allCommands = selection.commands.length === artifactInfo.commands.length;
+  return allAgent && allSkills && allCommands;
+}
+
+/**
+ * Check if no components were selected.
+ */
+export function isEmptySelection(selection: ComponentSelection): boolean {
+  return !selection.agent && selection.skills.length === 0 && selection.commands.length === 0;
+}

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -1,3 +1,4 @@
 // Auth domain barrel export
 export * from "./credentials/credentials";
 export * from "./session/session";
+export * from "./oauth/oauth";

--- a/src/auth/oauth/oauth.test.ts
+++ b/src/auth/oauth/oauth.test.ts
@@ -1,0 +1,25 @@
+import { describe, test } from "bun:test";
+
+describe("oauth", () => {
+  describe("openBrowser", () => {
+    test.todo("returns true when browser opens successfully");
+    test.todo("returns false when browser fails to open");
+    test.todo("uses correct command for macOS");
+    test.todo("uses correct command for Windows");
+    test.todo("uses correct command for Linux");
+  });
+
+  describe("browserLogin", () => {
+    test.todo("starts local HTTP server");
+    test.todo("generates auth URL with PKCE");
+    test.todo("calls onAuthUrl callback with URL");
+    test.todo("exchanges code for session on callback");
+    test.todo("rejects on OAuth error");
+    test.todo("rejects on timeout");
+  });
+
+  describe("emailLogin", () => {
+    test.todo("calls signInWithPassword");
+    test.todo("throws on invalid credentials");
+  });
+});

--- a/src/auth/oauth/oauth.ts
+++ b/src/auth/oauth/oauth.ts
@@ -1,0 +1,210 @@
+import { createServer, type Server } from "http";
+import { execSync } from "child_process";
+import { getSupabaseClient } from "#/auth/session/session";
+
+const LOGIN_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Open a URL in the default browser.
+ * Supports macOS, Windows, and Linux.
+ */
+export function openBrowser(url: string): boolean {
+  const platform = process.platform;
+  let command: string;
+
+  if (platform === "darwin") {
+    command = `open "${url}"`;
+  } else if (platform === "win32") {
+    command = `start "" "${url}"`;
+  } else {
+    command = `xdg-open "${url}"`;
+  }
+
+  try {
+    execSync(command, { stdio: "ignore" });
+    return true;
+  } catch {
+    // If browser fails to open, user will need to copy the URL manually
+    return false;
+  }
+}
+
+/**
+ * HTML template for success page.
+ */
+function successHtml(): string {
+  return `
+    <!DOCTYPE html>
+    <html>
+      <head><title>Login Successful</title></head>
+      <body style="font-family: system-ui; padding: 40px; text-align: center;">
+        <h1>Login Successful</h1>
+        <p>You can close this window and return to the terminal.</p>
+      </body>
+    </html>
+  `;
+}
+
+/**
+ * HTML template for error page.
+ */
+function errorHtml(message: string): string {
+  return `
+    <!DOCTYPE html>
+    <html>
+      <head><title>Login Failed</title></head>
+      <body style="font-family: system-ui; padding: 40px; text-align: center;">
+        <h1>Login Failed</h1>
+        <p>${message}</p>
+        <p>You can close this window.</p>
+      </body>
+    </html>
+  `;
+}
+
+/**
+ * HTML template for invalid request page.
+ */
+function invalidRequestHtml(): string {
+  return `
+    <!DOCTYPE html>
+    <html>
+      <head><title>Invalid Request</title></head>
+      <body style="font-family: system-ui; padding: 40px; text-align: center;">
+        <h1>Invalid Request</h1>
+        <p>No authorization code received.</p>
+      </body>
+    </html>
+  `;
+}
+
+export interface BrowserLoginResult {
+  success: boolean;
+  authUrl?: string;
+}
+
+export interface BrowserLoginCallbacks {
+  onAuthUrl?: (url: string) => void;
+}
+
+/**
+ * OAuth login flow with Supabase Auth.
+ * Starts a local HTTP server to receive the OAuth callback.
+ */
+export async function browserLogin(callbacks?: BrowserLoginCallbacks): Promise<void> {
+  const supabase = getSupabaseClient();
+
+  return new Promise((resolve, reject) => {
+    let server: Server;
+    let timeoutId: NodeJS.Timeout;
+
+    const cleanup = () => {
+      clearTimeout(timeoutId);
+      server?.close();
+    };
+
+    server = createServer(async (req, res) => {
+      const url = new URL(req.url!, `http://localhost`);
+      const code = url.searchParams.get("code");
+      const errorParam = url.searchParams.get("error");
+      const errorDescription = url.searchParams.get("error_description");
+
+      res.setHeader("Content-Type", "text/html");
+
+      if (errorParam) {
+        res.statusCode = 400;
+        res.end(errorHtml(errorDescription || errorParam));
+        cleanup();
+        reject(new Error(errorDescription || errorParam));
+        return;
+      }
+
+      if (code) {
+        try {
+          // Exchange code for session
+          const { error: exchangeError } = await supabase.auth.exchangeCodeForSession(code);
+
+          if (exchangeError) {
+            throw exchangeError;
+          }
+
+          res.statusCode = 200;
+          res.end(successHtml());
+          cleanup();
+          resolve();
+        } catch (err) {
+          res.statusCode = 400;
+          res.end(errorHtml(err instanceof Error ? err.message : "Failed to exchange code"));
+          cleanup();
+          reject(err);
+        }
+        return;
+      }
+
+      // No code or error - invalid request
+      res.statusCode = 400;
+      res.end(invalidRequestHtml());
+    });
+
+    // Bind explicitly to 127.0.0.1, never 0.0.0.0
+    server.listen(0, "127.0.0.1", async () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        cleanup();
+        reject(new Error("Failed to start local server"));
+        return;
+      }
+
+      const port = address.port;
+      const redirectUrl = `http://localhost:${port}/callback`;
+
+      // Use Supabase SDK to generate auth URL with PKCE
+      const { data, error: oauthError } = await supabase.auth.signInWithOAuth({
+        provider: "github",
+        options: {
+          redirectTo: redirectUrl,
+          skipBrowserRedirect: true,
+        },
+      });
+
+      if (oauthError || !data.url) {
+        cleanup();
+        reject(oauthError || new Error("Failed to generate auth URL"));
+        return;
+      }
+
+      // Notify caller of auth URL
+      callbacks?.onAuthUrl?.(data.url);
+
+      // Try to open browser
+      openBrowser(data.url);
+    });
+
+    // Timeout after 5 minutes
+    timeoutId = setTimeout(() => {
+      cleanup();
+      reject(new Error("Login timed out. Please try again."));
+    }, LOGIN_TIMEOUT_MS);
+
+    server.on("error", (err) => {
+      cleanup();
+      reject(err);
+    });
+  });
+}
+
+/**
+ * Email/password login (non-interactive, for CI/CD).
+ */
+export async function emailLogin(email: string, password: string): Promise<void> {
+  const supabase = getSupabaseClient();
+
+  const { error: signInError } = await supabase.auth.signInWithPassword({
+    email,
+    password,
+  });
+
+  if (signInError) {
+    throw signInError;
+  }
+}

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,134 +1,17 @@
 import { Command } from "commander";
-import { existsSync, mkdirSync, rmSync, unlinkSync, readdirSync, renameSync } from "fs";
-import { join } from "path";
-import { checkbox } from "@inquirer/prompts";
+import { existsSync, mkdirSync, rmSync, renameSync } from "fs";
 import { isInitialized, getConfig, saveConfig } from "#/config/project/project";
 import { getLockfile, saveLockfile } from "#/artifact/lockfile/lockfile";
 import { ARTIFACTS_DIR } from "#/config/paths/paths";
 import { parseSource, downloadFromSource, getSourceDisplayName } from "#/registry/sources/sources";
-import { scanArtifact, getArtifactId, type ArtifactInfo } from "#/artifact/scanner/scanner";
+import { scanArtifact, getArtifactId } from "#/artifact/scanner/scanner";
 import { hashDirectory, calculateIntegrity, getDirectorySize, formatBytes, estimateTokens } from "#/artifact/integrity/integrity";
+import { selectComponents, isEmptySelection, isFullSelection } from "#/artifact/selector/selector";
+import { removeUnselectedFiles } from "#/artifact/component-manager/component-manager";
 import { runCheck, displayCompactCheckResults } from "#/artifact/check/check";
 import { success, error, info, log, warning, newline, colors, spinner } from "#/shared/ui/ui";
 
 const CONTEXT_WARNING_THRESHOLD = 10 * 1024; // 10 KB
-
-interface ComponentSelection {
-  agent: string | undefined;
-  skills: string[];
-  commands: string[];
-}
-
-async function selectComponents(artifactInfo: ArtifactInfo): Promise<ComponentSelection> {
-  const choices: Array<{ name: string; value: { type: string; path: string }; checked: boolean }> = [];
-
-  if (artifactInfo.agent) {
-    choices.push({
-      name: `agent: ${artifactInfo.agent.parsed.frontmatter.name}`,
-      value: { type: "agent", path: artifactInfo.agent.path },
-      checked: true,
-    });
-  }
-
-  for (const skill of artifactInfo.skills) {
-    choices.push({
-      name: `skill: ${skill.parsed.frontmatter.name}`,
-      value: { type: "skill", path: skill.path },
-      checked: true,
-    });
-  }
-
-  for (const cmd of artifactInfo.commands) {
-    choices.push({
-      name: `command: ${cmd.parsed.frontmatter.name}`,
-      value: { type: "command", path: cmd.path },
-      checked: true,
-    });
-  }
-
-  const selected = await checkbox({
-    message: "Select components to install:",
-    choices,
-  });
-
-  const result: ComponentSelection = {
-    agent: undefined,
-    skills: [],
-    commands: [],
-  };
-
-  for (const item of selected) {
-    if (item.type === "agent") {
-      result.agent = item.path;
-    } else if (item.type === "skill") {
-      result.skills.push(item.path);
-    } else if (item.type === "command") {
-      result.commands.push(item.path);
-    }
-  }
-
-  return result;
-}
-
-/**
- * Remove unselected component files from artifact directory
- */
-function removeUnselectedFiles(
-  artifactDir: string,
-  artifactInfo: ArtifactInfo,
-  selection: ComponentSelection
-): void {
-  // Remove unselected agent
-  if (artifactInfo.agent && !selection.agent) {
-    const agentPath = join(artifactDir, artifactInfo.agent.path);
-    if (existsSync(agentPath)) {
-      unlinkSync(agentPath);
-    }
-  }
-
-  // Remove unselected skills
-  for (const skill of artifactInfo.skills) {
-    if (!selection.skills.includes(skill.path)) {
-      const skillPath = join(artifactDir, skill.path);
-      if (existsSync(skillPath)) {
-        unlinkSync(skillPath);
-      }
-    }
-  }
-
-  // Remove unselected commands
-  for (const cmd of artifactInfo.commands) {
-    if (!selection.commands.includes(cmd.path)) {
-      const cmdPath = join(artifactDir, cmd.path);
-      if (existsSync(cmdPath)) {
-        unlinkSync(cmdPath);
-      }
-    }
-  }
-
-  // Clean up empty directories
-  cleanEmptyDirs(artifactDir);
-}
-
-/**
- * Recursively remove empty directories
- */
-function cleanEmptyDirs(dir: string): void {
-  const entries = readdirSync(dir, { withFileTypes: true });
-
-  for (const entry of entries) {
-    if (entry.isDirectory()) {
-      const subdir = join(dir, entry.name);
-      cleanEmptyDirs(subdir);
-
-      // Check if directory is now empty
-      const remaining = readdirSync(subdir);
-      if (remaining.length === 0) {
-        rmSync(subdir);
-      }
-    }
-  }
-}
 
 export const addCommand = new Command("add")
   .description("Add an artifact from registry, GitHub, or GitLab")
@@ -225,7 +108,7 @@ export const addCommand = new Command("add")
         selectedSkills = selection.skills;
         selectedCommands = selection.commands;
 
-        if (!selectedAgent && selectedSkills.length === 0 && selectedCommands.length === 0) {
+        if (isEmptySelection(selection)) {
           warning("No components selected");
           rmSync(targetDir, { recursive: true, force: true });
           process.exit(0);
@@ -244,10 +127,8 @@ export const addCommand = new Command("add")
     const config = getConfig(projectRoot);
 
     // Check if all components were selected (no --choose or all selected)
-    const allAgent = artifactInfo.agent ? selectedAgent === artifactInfo.agent.path : true;
-    const allSkills = selectedSkills.length === artifactInfo.skills.length;
-    const allCommands = selectedCommands.length === artifactInfo.commands.length;
-    const allSelected = allAgent && allSkills && allCommands;
+    const currentSelection = { agent: selectedAgent, skills: selectedSkills, commands: selectedCommands };
+    const allSelected = isFullSelection(artifactInfo, currentSelection);
 
     if (allSelected) {
       // Simple format: just version

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,42 +1,13 @@
 import { Command } from "commander";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
-import { execSync } from "child_process";
+import { existsSync, mkdirSync, rmSync } from "fs";
 import { isInitialized, getConfig } from "#/config/project/project";
 import { getLockfile, lockfileExists } from "#/artifact/lockfile/lockfile";
 import { ARTIFACTS_DIR } from "#/config/paths/paths";
 import { parseSource, downloadFromSource } from "#/registry/sources/sources";
-import { hashDirectory, verifyIntegrity } from "#/artifact/integrity/integrity";
+import { downloadAndExtractTarball } from "#/registry/download/download";
+import { verifyIntegrity } from "#/artifact/integrity/integrity";
 import { runCheck, displayCompactCheckResults } from "#/artifact/check/check";
 import { success, error, info, warning, log, newline, colors, spinner } from "#/shared/ui/ui";
-
-/**
- * Download directly from a resolved URL
- */
-async function downloadFromUrl(url: string, targetDir: string): Promise<boolean> {
-  try {
-    const response = await fetch(url, {
-      headers: { "User-Agent": "grekt-cli" },
-    });
-
-    if (!response.ok) {
-      return false;
-    }
-
-    const buffer = await response.arrayBuffer();
-    const tempTarball = `/tmp/grekt-${Date.now()}.tar.gz`;
-    writeFileSync(tempTarball, Buffer.from(buffer));
-
-    mkdirSync(targetDir, { recursive: true });
-    execSync(`tar -xzf ${tempTarball} -C ${targetDir} --strip-components=1`, {
-      stdio: "pipe",
-    });
-    execSync(`rm -f ${tempTarball}`, { stdio: "pipe" });
-
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 export const installCommand = new Command("install")
   .alias("i")
@@ -108,8 +79,8 @@ export const installCommand = new Command("install")
 
       // Use resolved URL if available (strict mode - no recalculation)
       if (entry.resolved) {
-        mkdirSync(targetDir, { recursive: true });
-        downloadSuccess = await downloadFromUrl(entry.resolved, targetDir);
+        const result = await downloadAndExtractTarball(entry.resolved, targetDir);
+        downloadSuccess = result.success;
       } else {
         // Fallback for old lockfiles without resolved
         const sourceStr = entry.source || artifactId;
@@ -135,7 +106,6 @@ export const installCommand = new Command("install")
       }
 
       // Verify integrity
-      const actualHashes = hashDirectory(targetDir);
       const integrity = verifyIntegrity(targetDir, entry.files);
 
       if (!integrity.valid) {

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -1,9 +1,10 @@
 import { Command } from "commander";
 import { existsSync, rmSync, readdirSync, unlinkSync } from "fs";
-import { basename, join } from "path";
+import { join } from "path";
 import { confirm } from "@inquirer/prompts";
 import { isInitialized, getConfig, saveConfig } from "#/config/project/project";
 import { getLockfile, saveLockfile } from "#/artifact/lockfile/lockfile";
+import { getSafeFilename } from "#/artifact/naming/naming";
 import { ARTIFACTS_DIR } from "#/config/paths/paths";
 import { success, error, info, log, newline, colors } from "#/shared/ui/ui";
 
@@ -12,15 +13,6 @@ const CLAUDE_DIR = ".claude";
 const CLAUDE_AGENTS_DIR = join(CLAUDE_DIR, "agents");
 const CLAUDE_SKILLS_DIR = join(CLAUDE_DIR, "skills");
 const CLAUDE_COMMANDS_DIR = join(CLAUDE_DIR, "commands");
-
-/**
- * Get namespaced filename (must match claude.ts getSafeFilename)
- */
-function getSafeFilename(artifactId: string, filepath: string): string {
-  const safeName = artifactId.replace("@", "").replace("/", "-");
-  const filename = basename(filepath);
-  return `${safeName}_${filename}`;
-}
 
 export const removeCommand = new Command("remove")
   .alias("rm")

--- a/src/registry/download/download.test.ts
+++ b/src/registry/download/download.test.ts
@@ -1,0 +1,14 @@
+import { describe, test } from "bun:test";
+
+describe("download", () => {
+  test.todo("downloadAndExtractTarball downloads and extracts tarball");
+  test.todo("downloadAndExtractTarball handles HTTP errors");
+  test.todo("downloadAndExtractTarball cleans up temp files on failure");
+  test.todo("downloadAndExtractTarball respects stripComponents option");
+  test.todo("buildGitHubTarballUrl builds correct URL");
+  test.todo("buildGitHubTarballUrl handles ref parameter");
+  test.todo("buildGitLabArchiveUrl builds correct URL");
+  test.todo("buildGitLabArchiveUrl encodes project path");
+  test.todo("getGitHubHeaders includes auth when token provided");
+  test.todo("getGitLabHeaders uses PRIVATE-TOKEN header");
+});

--- a/src/registry/download/download.ts
+++ b/src/registry/download/download.ts
@@ -1,0 +1,126 @@
+import { mkdirSync, writeFileSync, existsSync, rmSync } from "fs";
+import { execSync } from "child_process";
+import { tmpdir } from "os";
+import { join } from "path";
+
+export interface DownloadOptions {
+  headers?: Record<string, string>;
+  stripComponents?: number;
+}
+
+export interface TarballDownloadResult {
+  success: boolean;
+  error?: string;
+}
+
+/**
+ * Download a tarball from URL and extract to target directory.
+ * Handles temp file creation, extraction, and cleanup.
+ *
+ * @param url - URL to download tarball from
+ * @param targetDir - Directory to extract contents to
+ * @param options - Optional headers and extraction options
+ */
+export async function downloadAndExtractTarball(
+  url: string,
+  targetDir: string,
+  options: DownloadOptions = {}
+): Promise<TarballDownloadResult> {
+  const { headers = {}, stripComponents = 1 } = options;
+
+  // Ensure User-Agent is always set
+  const finalHeaders: Record<string, string> = {
+    "User-Agent": "grekt-cli",
+    ...headers,
+  };
+
+  const tempTarball = join(tmpdir(), `grekt-${Date.now()}.tar.gz`);
+
+  try {
+    const response = await fetch(url, {
+      headers: finalHeaders,
+      redirect: "follow",
+    });
+
+    if (!response.ok) {
+      return {
+        success: false,
+        error: `HTTP ${response.status}: ${response.statusText}`,
+      };
+    }
+
+    const buffer = await response.arrayBuffer();
+    writeFileSync(tempTarball, Buffer.from(buffer));
+
+    // Ensure target directory exists
+    mkdirSync(targetDir, { recursive: true });
+
+    // Extract tarball
+    const stripArg = stripComponents > 0 ? `--strip-components=${stripComponents}` : "";
+    execSync(`tar -xzf ${tempTarball} -C ${targetDir} ${stripArg}`, {
+      stdio: "pipe",
+    });
+
+    return { success: true };
+  } catch (err) {
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : "Unknown error",
+    };
+  } finally {
+    // Always clean up temp file
+    if (existsSync(tempTarball)) {
+      rmSync(tempTarball, { force: true });
+    }
+  }
+}
+
+/**
+ * Build GitHub API tarball URL for a repository.
+ */
+export function buildGitHubTarballUrl(owner: string, repo: string, ref: string = "HEAD"): string {
+  return `https://api.github.com/repos/${owner}/${repo}/tarball/${ref}`;
+}
+
+/**
+ * Build GitLab API archive URL for a project.
+ */
+export function buildGitLabArchiveUrl(
+  host: string,
+  projectPath: string,
+  ref: string = "main"
+): string {
+  const encodedProject = encodeURIComponent(projectPath);
+  return `https://${host}/api/v4/projects/${encodedProject}/repository/archive.tar.gz?sha=${ref}`;
+}
+
+/**
+ * Get headers for GitHub API requests.
+ */
+export function getGitHubHeaders(token?: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "grekt-cli",
+  };
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  return headers;
+}
+
+/**
+ * Get headers for GitLab API requests.
+ */
+export function getGitLabHeaders(token?: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    "User-Agent": "grekt-cli",
+  };
+
+  if (token) {
+    headers["PRIVATE-TOKEN"] = token;
+  }
+
+  return headers;
+}

--- a/src/registry/publishers/api-publisher.ts
+++ b/src/registry/publishers/api-publisher.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from "fs";
+import { isAuthenticated, isSupabaseConfigured } from "#/auth/session/session";
+import { createRegistryClient } from "#/registry/api-client/api-client";
+import type { Publisher, PublishContext, PublishResult } from "./publisher.types";
+
+/**
+ * Publisher for the default API-based registry (Supabase).
+ */
+export class ApiPublisher implements Publisher {
+  readonly type = "api";
+
+  async versionExists(ctx: PublishContext): Promise<boolean> {
+    const authenticated = await isAuthenticated();
+    if (!authenticated) {
+      return false;
+    }
+
+    const client = createRegistryClient();
+    try {
+      return await client.versionExists(ctx.artifactId, ctx.version);
+    } catch {
+      return false;
+    }
+  }
+
+  async publish(ctx: PublishContext): Promise<PublishResult> {
+    const authenticated = await isAuthenticated();
+
+    if (!authenticated) {
+      return {
+        success: false,
+        error: "Not logged in. Run 'grekt login' first.",
+      };
+    }
+
+    const client = createRegistryClient();
+
+    try {
+      const { uploadUrl } = await client.publish(ctx.artifactId, ctx.version);
+
+      // Upload tarball to signed URL
+      const body = readFileSync(ctx.tarballPath);
+      const uploadResponse = await fetch(uploadUrl, {
+        method: "PUT",
+        body,
+        headers: { "Content-Type": "application/gzip" },
+      });
+
+      if (!uploadResponse.ok) {
+        return {
+          success: false,
+          error: `Upload failed: ${uploadResponse.status}`,
+        };
+      }
+
+      return { success: true };
+    } catch (err) {
+      return {
+        success: false,
+        error: err instanceof Error ? err.message : "Unknown error",
+      };
+    }
+  }
+}
+
+/**
+ * Check if user is authenticated for API publishing.
+ * Returns false if Supabase is not configured.
+ */
+export async function isApiAuthenticated(): Promise<boolean> {
+  if (!isSupabaseConfigured()) {
+    return false;
+  }
+  try {
+    return await isAuthenticated();
+  } catch {
+    return false;
+  }
+}

--- a/src/registry/publishers/custom-publisher.ts
+++ b/src/registry/publishers/custom-publisher.ts
@@ -1,0 +1,57 @@
+import { createRegistryClient } from "#/registry/factory/factory";
+import type { ResolvedRegistry } from "#/registry/registry.types";
+import type { Publisher, PublishContext, PublishResult } from "./publisher.types";
+
+/**
+ * Publisher for custom registries (GitLab, GitHub, etc.).
+ */
+export class CustomPublisher implements Publisher {
+  readonly type: string;
+  private registry: ResolvedRegistry;
+
+  constructor(registry: ResolvedRegistry) {
+    this.type = registry.type;
+    this.registry = registry;
+  }
+
+  async versionExists(ctx: PublishContext): Promise<boolean> {
+    const client = createRegistryClient(this.registry);
+    try {
+      return await client.versionExists(ctx.artifactId, ctx.version);
+    } catch {
+      return false;
+    }
+  }
+
+  async publish(ctx: PublishContext): Promise<PublishResult> {
+    const client = createRegistryClient(this.registry);
+
+    try {
+      const result = await client.publish(ctx.artifactId, ctx.version, ctx.tarballPath);
+
+      if (!result.success) {
+        return {
+          success: false,
+          error: result.error || "Unknown error",
+        };
+      }
+
+      return {
+        success: true,
+        url: result.url,
+      };
+    } catch (err) {
+      return {
+        success: false,
+        error: err instanceof Error ? err.message : "Unknown error",
+      };
+    }
+  }
+
+  /**
+   * Get the registry configuration for error messages.
+   */
+  getRegistry(): ResolvedRegistry {
+    return this.registry;
+  }
+}

--- a/src/registry/publishers/factory.ts
+++ b/src/registry/publishers/factory.ts
@@ -1,0 +1,66 @@
+import { getLocalConfig } from "#/config/project/project";
+import { resolveRegistry } from "#/registry/resolver/resolver";
+import type { Publisher } from "./publisher.types";
+import { ApiPublisher } from "./api-publisher";
+import { CustomPublisher } from "./custom-publisher";
+import { S3Publisher } from "./s3-publisher";
+
+export interface PublisherOptions {
+  /**
+   * Force S3 legacy mode.
+   */
+  s3?: boolean;
+  /**
+   * Scope of the artifact (@author).
+   */
+  scope: string;
+  /**
+   * Project root for config lookup.
+   */
+  projectRoot: string;
+}
+
+/**
+ * Create the appropriate publisher based on options and configuration.
+ *
+ * Priority:
+ * 1. --s3 flag → S3Publisher (legacy, env vars only)
+ * 2. Custom registry config → CustomPublisher
+ * 3. Default → ApiPublisher
+ */
+export function createPublisher(options: PublisherOptions): Publisher {
+  // S3 legacy mode takes priority
+  if (options.s3) {
+    return new S3Publisher();
+  }
+
+  // Check for custom registry configuration
+  const localConfig = getLocalConfig(options.projectRoot);
+  const registry = resolveRegistry(options.scope, localConfig);
+
+  if (registry.type !== "default") {
+    // Use custom registry (GitLab, GitHub, etc.)
+    return new CustomPublisher(registry);
+  }
+
+  // Use default API-based registry
+  return new ApiPublisher();
+}
+
+/**
+ * Get publisher type name for display.
+ */
+export function getPublisherTypeName(publisher: Publisher): string {
+  switch (publisher.type) {
+    case "api":
+      return "grekt registry";
+    case "s3":
+      return "S3 storage";
+    case "gitlab":
+      return "GitLab registry";
+    case "github":
+      return "GitHub registry";
+    default:
+      return `${publisher.type} registry`;
+  }
+}

--- a/src/registry/publishers/publisher.types.ts
+++ b/src/registry/publishers/publisher.types.ts
@@ -1,0 +1,39 @@
+/**
+ * Result of a publish operation.
+ */
+export interface PublishResult {
+  success: boolean;
+  url?: string;
+  error?: string;
+}
+
+/**
+ * Context passed to publishers with all necessary information.
+ */
+export interface PublishContext {
+  artifactId: string;
+  version: string;
+  tarballPath: string;
+  scope: string;
+  projectRoot: string;
+}
+
+/**
+ * Publisher interface - Strategy pattern for different registry types.
+ */
+export interface Publisher {
+  /**
+   * Unique identifier for this publisher type.
+   */
+  readonly type: string;
+
+  /**
+   * Check if a version already exists.
+   */
+  versionExists(ctx: PublishContext): Promise<boolean>;
+
+  /**
+   * Publish the artifact.
+   */
+  publish(ctx: PublishContext): Promise<PublishResult>;
+}

--- a/src/registry/publishers/publishers.test.ts
+++ b/src/registry/publishers/publishers.test.ts
@@ -1,0 +1,28 @@
+import { describe, test } from "bun:test";
+
+describe("publishers", () => {
+  describe("factory", () => {
+    test.todo("createPublisher returns S3Publisher when s3 option is true");
+    test.todo("createPublisher returns CustomPublisher for custom registry");
+    test.todo("createPublisher returns ApiPublisher for default registry");
+    test.todo("getPublisherTypeName returns correct names");
+  });
+
+  describe("ApiPublisher", () => {
+    test.todo("versionExists returns false when not authenticated");
+    test.todo("publish returns error when not authenticated");
+    test.todo("publish uploads to signed URL");
+  });
+
+  describe("CustomPublisher", () => {
+    test.todo("uses registry client for version check");
+    test.todo("publish delegates to registry client");
+  });
+
+  describe("S3Publisher", () => {
+    test.todo("hasCredentials returns false without credentials");
+    test.todo("getCredentials checks env vars first");
+    test.todo("publish uploads to S3 bucket");
+    test.todo("publish updates metadata after upload");
+  });
+});

--- a/src/registry/publishers/s3-publisher.ts
+++ b/src/registry/publishers/s3-publisher.ts
@@ -1,0 +1,146 @@
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import { readFileSync } from "fs";
+import type { S3Credentials } from "#/schemas/index";
+import {
+  getArtifactMetadata,
+  saveArtifactMetadata,
+  versionExists as checkS3VersionExists,
+  createMetadata,
+  updateMetadataVersion,
+} from "#/registry/metadata/metadata";
+import type { Publisher, PublishContext, PublishResult } from "./publisher.types";
+
+/**
+ * Get S3 credentials from environment variables.
+ * Used for CI/CD workflows.
+ */
+export function getS3CredentialsFromEnv(): S3Credentials | undefined {
+  const {
+    GREKT_STORAGE_ENDPOINT,
+    GREKT_STORAGE_ACCESS_KEY_ID,
+    GREKT_STORAGE_SECRET_ACCESS_KEY,
+    GREKT_STORAGE_BUCKET,
+    GREKT_STORAGE_PUBLIC_URL,
+    // Legacy env vars (backwards compat)
+    STORAGE_ENDPOINT,
+    STORAGE_ACCESS_KEY_ID,
+    STORAGE_SECRET_ACCESS_KEY,
+    STORAGE_BUCKET,
+    STORAGE_PUBLIC_URL,
+  } = process.env;
+
+  const endpoint = GREKT_STORAGE_ENDPOINT || STORAGE_ENDPOINT;
+  const accessKeyId = GREKT_STORAGE_ACCESS_KEY_ID || STORAGE_ACCESS_KEY_ID;
+  const secretAccessKey = GREKT_STORAGE_SECRET_ACCESS_KEY || STORAGE_SECRET_ACCESS_KEY;
+  const bucket = GREKT_STORAGE_BUCKET || STORAGE_BUCKET;
+  const publicUrl = GREKT_STORAGE_PUBLIC_URL || STORAGE_PUBLIC_URL;
+
+  if (!endpoint || !accessKeyId || !secretAccessKey || !bucket) {
+    return undefined;
+  }
+
+  return {
+    type: "s3",
+    endpoint,
+    accessKeyId,
+    secretAccessKey,
+    bucket,
+    publicUrl,
+  };
+}
+
+/**
+ * Publisher for S3-compatible storage (legacy mode).
+ * Credentials are only read from environment variables.
+ */
+export class S3Publisher implements Publisher {
+  readonly type = "s3";
+  private credentials: S3Credentials | undefined = undefined;
+
+  /**
+   * Get credentials from environment variables.
+   */
+  private getCredentials(): S3Credentials | undefined {
+    if (this.credentials) {
+      return this.credentials;
+    }
+
+    this.credentials = getS3CredentialsFromEnv();
+    return this.credentials;
+  }
+
+  /**
+   * Check if credentials are available.
+   */
+  hasCredentials(): boolean {
+    return this.getCredentials() !== undefined;
+  }
+
+  async versionExists(ctx: PublishContext): Promise<boolean> {
+    const credentials = this.getCredentials();
+    if (!credentials) {
+      return false;
+    }
+
+    try {
+      return await checkS3VersionExists(credentials, ctx.artifactId, ctx.version);
+    } catch {
+      return false;
+    }
+  }
+
+  async publish(ctx: PublishContext): Promise<PublishResult> {
+    const credentials = this.getCredentials();
+
+    if (!credentials) {
+      return {
+        success: false,
+        error: "No S3 credentials found",
+      };
+    }
+
+    const client = new S3Client({
+      region: "auto",
+      endpoint: credentials.endpoint,
+      credentials: {
+        accessKeyId: credentials.accessKeyId,
+        secretAccessKey: credentials.secretAccessKey,
+      },
+    });
+
+    const key = `artifacts/${ctx.artifactId}/${ctx.version}.tar.gz`;
+    const body = readFileSync(ctx.tarballPath);
+
+    try {
+      await client.send(
+        new PutObjectCommand({
+          Bucket: credentials.bucket,
+          Key: key,
+          Body: body,
+          ContentType: "application/gzip",
+        })
+      );
+
+      // Update metadata
+      let metadata = await getArtifactMetadata(credentials, ctx.artifactId);
+      if (metadata) {
+        metadata = updateMetadataVersion(metadata, ctx.version);
+      } else {
+        metadata = createMetadata(ctx.artifactId, ctx.version);
+      }
+      await saveArtifactMetadata(credentials, metadata);
+
+      const url = credentials.publicUrl ? `${credentials.publicUrl}/${key}` : undefined;
+
+      return {
+        success: true,
+        url,
+      };
+    } catch (err) {
+      return {
+        success: false,
+        error: err instanceof Error ? err.message : "Unknown error",
+      };
+    }
+  }
+}

--- a/src/registry/sources/sources.ts
+++ b/src/registry/sources/sources.ts
@@ -1,5 +1,3 @@
-import { mkdirSync, writeFileSync, existsSync } from "fs";
-import { execSync } from "child_process";
 import { getTokenCredentials } from "#/auth/credentials/credentials";
 import { getLocalConfig } from "#/config/project/project";
 import {
@@ -8,6 +6,13 @@ import {
   resolveRegistry,
   createRegistryClient,
 } from "#/registry/registry";
+import {
+  downloadAndExtractTarball,
+  buildGitHubTarballUrl,
+  buildGitLabArchiveUrl,
+  getGitHubHeaders,
+  getGitLabHeaders,
+} from "#/registry/download/download";
 
 export type SourceType = "registry" | "github" | "gitlab";
 
@@ -126,45 +131,17 @@ async function downloadFromGitHub(
 ): Promise<DownloadResult> {
   const token = getSourceToken(source);
   const ref = source.ref || "HEAD";
+  const [owner, repo] = source.identifier.split("/");
 
-  // GitHub tarball URL
-  const tarballUrl = `https://api.github.com/repos/${source.identifier}/tarball/${ref}`;
+  const url = buildGitHubTarballUrl(owner!, repo!, ref);
+  const headers = getGitHubHeaders(token);
 
-  const headers: Record<string, string> = {
-    Accept: "application/vnd.github+json",
-    "User-Agent": "grekt-cli",
-  };
+  const result = await downloadAndExtractTarball(url, targetDir, { headers });
 
-  if (token) {
-    headers.Authorization = `Bearer ${token}`;
-  }
-
-  try {
-    const response = await fetch(tarballUrl, {
-      headers,
-      redirect: "follow",
-    });
-
-    if (!response.ok) {
-      return { success: false };
-    }
-
-    const buffer = await response.arrayBuffer();
-    const tempTarball = `/tmp/grekt-github-${Date.now()}.tar.gz`;
-    writeFileSync(tempTarball, Buffer.from(buffer));
-
-    mkdirSync(targetDir, { recursive: true });
-
-    // Extract with strip-components to remove the GitHub-generated root folder
-    execSync(`tar -xzf ${tempTarball} -C ${targetDir} --strip-components=1`, {
-      stdio: "pipe",
-    });
-    execSync(`rm -f ${tempTarball}`, { stdio: "pipe" });
-
+  if (result.success) {
     return { success: true, version: ref };
-  } catch {
-    return { success: false };
   }
+  return { success: false };
 }
 
 async function downloadFromGitLab(
@@ -175,46 +152,15 @@ async function downloadFromGitLab(
   const host = source.host || "gitlab.com";
   const ref = source.ref || "main";
 
-  // URL-encode the project path for GitLab API
-  const encodedProject = encodeURIComponent(source.identifier);
+  const url = buildGitLabArchiveUrl(host, source.identifier, ref);
+  const headers = getGitLabHeaders(token);
 
-  // GitLab archive URL
-  const archiveUrl = `https://${host}/api/v4/projects/${encodedProject}/repository/archive.tar.gz?sha=${ref}`;
+  const result = await downloadAndExtractTarball(url, targetDir, { headers });
 
-  const headers: Record<string, string> = {
-    "User-Agent": "grekt-cli",
-  };
-
-  if (token) {
-    headers["PRIVATE-TOKEN"] = token;
-  }
-
-  try {
-    const response = await fetch(archiveUrl, {
-      headers,
-      redirect: "follow",
-    });
-
-    if (!response.ok) {
-      return { success: false };
-    }
-
-    const buffer = await response.arrayBuffer();
-    const tempTarball = `/tmp/grekt-gitlab-${Date.now()}.tar.gz`;
-    writeFileSync(tempTarball, Buffer.from(buffer));
-
-    mkdirSync(targetDir, { recursive: true });
-
-    // Extract with strip-components to remove the GitLab-generated root folder
-    execSync(`tar -xzf ${tempTarball} -C ${targetDir} --strip-components=1`, {
-      stdio: "pipe",
-    });
-    execSync(`rm -f ${tempTarball}`, { stdio: "pipe" });
-
+  if (result.success) {
     return { success: true, version: ref };
-  } catch {
-    return { success: false };
   }
+  return { success: false };
 }
 
 /**

--- a/src/shared/formatters/formatters.test.ts
+++ b/src/shared/formatters/formatters.test.ts
@@ -1,0 +1,10 @@
+import { describe, test } from "bun:test";
+
+describe("formatters", () => {
+  test.todo("formatBytes returns B for bytes < 1024");
+  test.todo("formatBytes returns KB for bytes < 1MB");
+  test.todo("formatBytes returns MB for bytes >= 1MB");
+  test.todo("estimateTokens divides bytes by 4");
+  test.todo("formatNumber adds thousand separators");
+  test.todo("formatTokenEstimate combines estimation and formatting");
+});

--- a/src/shared/formatters/formatters.ts
+++ b/src/shared/formatters/formatters.ts
@@ -1,0 +1,41 @@
+/**
+ * Format bytes to human readable string.
+ *
+ * @example formatBytes(500) → "500 B"
+ * @example formatBytes(1536) → "1.5 KB"
+ * @example formatBytes(1572864) → "1.5 MB"
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * Estimate token count from byte size.
+ * Uses rough approximation: ~4 chars per token, ~1 byte per char for ASCII.
+ *
+ * @example estimateTokens(4000) → 1000
+ */
+export function estimateTokens(bytes: number): number {
+  return Math.round(bytes / 4);
+}
+
+/**
+ * Format a number with thousand separators.
+ *
+ * @example formatNumber(1234567) → "1,234,567"
+ */
+export function formatNumber(num: number): string {
+  return num.toLocaleString("en-US");
+}
+
+/**
+ * Format token count with "~" prefix for estimates.
+ *
+ * @example formatTokenEstimate(1500) → "~1,500 tokens"
+ */
+export function formatTokenEstimate(bytes: number): string {
+  const tokens = estimateTokens(bytes);
+  return `~${formatNumber(tokens)} tokens`;
+}

--- a/src/sync/base/base.ts
+++ b/src/sync/base/base.ts
@@ -1,8 +1,9 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync } from "fs";
-import { dirname, join, basename } from "path";
+import { dirname, join } from "path";
 import type { SyncPlugin, SyncResult, SyncOptions, SyncPreview } from "#/sync/sync.types";
 import type { Lockfile } from "#/schemas/index";
 import { ARTIFACTS_DIR } from "#/config/paths/paths";
+import { getSafeFilename } from "#/artifact/naming/naming";
 
 // Shared constants
 export const GREKT_BLOCK_START = "<!-- GREKT -->";
@@ -16,15 +17,8 @@ export function ensureDir(filepath: string): void {
   }
 }
 
-/**
- * Create a namespaced filename to avoid collisions between artifacts.
- * @example getSafeFilename("my-artifact", "skills/analyze.md") → "my-artifact_analyze.md"
- */
-export function getSafeFilename(artifactId: string, filepath: string): string {
-  const safeName = artifactId.replace("@", "").replace("/", "-");
-  const filename = basename(filepath);
-  return `${safeName}_${filename}`;
-}
+// Re-export for backwards compatibility
+export { getSafeFilename } from "#/artifact/naming/naming";
 
 // Plugin configuration types
 export interface FolderPluginConfig {


### PR DESCRIPTION
- Extract OAuth flow to src/auth/oauth/
- Extract download utilities to src/registry/download/
- Extract publishers to src/registry/publishers/
- Extract component manager to src/artifact/component-manager/
- Extract naming utilities to src/artifact/naming/
- Extract selector to src/artifact/selector/
- Extract formatters to src/shared/formatters/
- Update imports across commands and modules