### PR TITLE
refactor: simplify token configuration

### DIFF
--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -189,6 +189,5 @@ function showGitLabHelp(scope: string): void {
   log(`         project: your/project`);
   log(`         token: glpat-xxx`);
   log("");
-  log(`  2. Set environment variable: GREKT_TOKEN_${scope.slice(1).toUpperCase()}`);
-  log(`  3. Set GITLAB_TOKEN environment variable`);
+  log(`  2. Set GITLAB_TOKEN environment variable`);
 }

--- a/src/registry/clients/gitlab/gitlab.ts
+++ b/src/registry/clients/gitlab/gitlab.ts
@@ -189,7 +189,7 @@ export class GitLabRegistryClient implements RegistryClient {
     if (!this.token) {
       return {
         success: false,
-        error: "GitLab registry requires authentication. Set token in .grekt/config.yaml or GREKT_TOKEN_* env var.",
+        error: "GitLab registry requires authentication. Set token in .grekt/config.yaml or GITLAB_TOKEN env var.",
       };
     }
 

--- a/src/registry/resolver/resolver.ts
+++ b/src/registry/resolver/resolver.ts
@@ -56,20 +56,6 @@ function getDefaultHost(type: RegistryType): string {
 }
 
 /**
- * Get token from environment variable for a scope
- *
- * @example
- * getEnvToken("@miscope") → process.env.GREKT_TOKEN_MISCOPE
- * getEnvToken("@my-team") → process.env.GREKT_TOKEN_MY_TEAM
- */
-function getEnvToken(scope: string): string | undefined {
-  // @miscope → GREKT_TOKEN_MISCOPE
-  // @my-team → GREKT_TOKEN_MY_TEAM
-  const envName = `GREKT_TOKEN_${scope.slice(1).replace(/-/g, "_").toUpperCase()}`;
-  return process.env[envName];
-}
-
-/**
  * Resolve a scope to a registry configuration
  *
  * Priority:
@@ -77,9 +63,8 @@ function getEnvToken(scope: string): string | undefined {
  * 2. Fall back to default public registry
  *
  * Token priority:
- * 1. Environment variable (GREKT_TOKEN_SCOPE)
- * 2. Config file token
- * 3. Generic token (GITLAB_TOKEN, GITHUB_TOKEN)
+ * 1. Config file token (.grekt/config.yaml)
+ * 2. Platform env vars (GITLAB_TOKEN, GITHUB_TOKEN)
  */
 export function resolveRegistry(
   scope: string,
@@ -95,11 +80,9 @@ export function resolveRegistry(
     };
   }
 
-  // Get token: env var takes priority
-  const envToken = getEnvToken(scope);
-  let token = envToken || entry.token;
+  // Get token from config, fall back to platform env vars
+  let token = entry.token;
 
-  // Fall back to generic tokens if no specific token
   if (!token) {
     if (entry.type === "gitlab") {
       token = process.env.GITLAB_TOKEN || process.env.GL_TOKEN;

--- a/src/registry/sources/sources.ts
+++ b/src/registry/sources/sources.ts
@@ -92,25 +92,15 @@ export function parseSource(source: string): ParsedSource {
   };
 }
 
+/**
+ * Get token for a git source
+ *
+ * Priority:
+ * 1. Config file (.grekt/config.yaml tokens section)
+ * 2. Platform env vars (GITHUB_TOKEN, GITLAB_TOKEN) - for users who already have them set
+ */
 function getSourceToken(source: ParsedSource, projectRoot: string): string | undefined {
-  // Check environment variables first (always takes priority)
-  if (source.type === "github") {
-    const envToken = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
-    if (envToken) return envToken;
-  }
-
-  if (source.type === "gitlab") {
-    // For self-hosted, check host-specific env var first
-    if (source.host && source.host !== "gitlab.com") {
-      const hostEnvKey = `GITLAB_TOKEN_${source.host.replace(/\./g, "_").toUpperCase()}`;
-      const hostToken = process.env[hostEnvKey];
-      if (hostToken) return hostToken;
-    }
-    const envToken = process.env.GITLAB_TOKEN || process.env.GL_TOKEN;
-    if (envToken) return envToken;
-  }
-
-  // Check project config (.grekt/config.yaml tokens section)
+  // Check project config first (.grekt/config.yaml tokens section)
   if (source.type === "github") {
     const token = getToken("github", projectRoot);
     if (token) return token;
@@ -119,6 +109,15 @@ function getSourceToken(source: ParsedSource, projectRoot: string): string | und
     const key = source.host || "gitlab.com";
     const token = getToken(key, projectRoot);
     if (token) return token;
+  }
+
+  // Fall back to platform env vars (users might already have these set)
+  if (source.type === "github") {
+    return process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  }
+
+  if (source.type === "gitlab") {
+    return process.env.GITLAB_TOKEN || process.env.GL_TOKEN;
   }
 
   return undefined;


### PR DESCRIPTION
Remove GREKT_TOKEN_* env var support. Token sources are now:

1. Config file (.grekt/config.yaml) - primary source
2. Platform env vars (GITHUB_TOKEN, GITLAB_TOKEN) - fallback only

This eliminates configuration duplication. Users configure tokens in one place (config file) and platform tokens work automatically if already set for other tools.