### PR TITLE
feat: add monorepo support with config walk-up

### DIFF
--- a/src/config/project/project.test.ts
+++ b/src/config/project/project.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { existsSync, mkdirSync, rmSync, writeFileSync, readFileSync } from "fs";
 import { join } from "path";
+import { tmpdir } from "os";
 import { stringify } from "yaml";
 import {
   getConfig,
@@ -17,7 +18,8 @@ import {
 import type { ProjectConfig, LocalConfig, StoredSession } from "@grekt-labs/cli-engine";
 
 describe("project", () => {
-  const testDir = join(process.cwd(), ".test-project");
+  // Use system temp to avoid finding .grekt/config.yaml in parent directories
+  const testDir = join(tmpdir(), ".grekt-test-project");
 
   beforeEach(() => {
     if (existsSync(testDir)) {
@@ -132,6 +134,33 @@ describe("project", () => {
       expect(config).not.toBeNull();
       expect(config!.registries!["@myorg"].type).toBe("gitlab");
       expect(config!.tokens!.github).toBe("gh-token");
+    });
+
+    test("walks up directory tree to find config (monorepo support)", () => {
+      // Create parent with config
+      mkdirSync(join(testDir, ".grekt"), { recursive: true });
+      const localConfigData: LocalConfig = {
+        registries: {
+          "@parent": {
+            type: "gitlab",
+            project: "parent/artifacts",
+          },
+        },
+      };
+      writeFileSync(
+        join(testDir, ".grekt", "config.yaml"),
+        stringify(localConfigData)
+      );
+
+      // Create nested subdirectory without config
+      const nestedDir = join(testDir, "packages", "subpackage");
+      mkdirSync(nestedDir, { recursive: true });
+
+      // Should find parent config from nested dir
+      const config = getLocalConfig(nestedDir);
+
+      expect(config).not.toBeNull();
+      expect(config!.registries!["@parent"].type).toBe("gitlab");
     });
   });
 

--- a/src/config/project/project.ts
+++ b/src/config/project/project.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from "fs";
-import { dirname } from "path";
+import { dirname, resolve } from "path";
 import { parse, stringify } from "yaml";
 import {
   ProjectConfigSchema,
@@ -63,10 +63,30 @@ export function isInitialized(projectRoot: string = process.cwd()): boolean {
   return existsSync(`${projectRoot}/${GREKT_YAML}`);
 }
 
+// Walk up directory tree to find .grekt/config.yaml
+function findLocalConfigPath(startDir: string): string | null {
+  let current = resolve(startDir);
+
+  while (true) {
+    const configPath = `${current}/${GREKT_DIR}/${LOCAL_CONFIG_FILE}`;
+    if (existsSync(configPath)) {
+      return configPath;
+    }
+
+    const parent = dirname(current);
+    if (parent === current) {
+      // Reached filesystem root
+      return null;
+    }
+    current = parent;
+  }
+}
+
 // Local config (.grekt/config.yaml) - gitignored, contains registry configs, session, and tokens
+// Walks up directory tree to find config (supports monorepos)
 export function getLocalConfig(projectRoot: string = process.cwd()): LocalConfig | null {
-  const filepath = `${projectRoot}/${GREKT_DIR}/${LOCAL_CONFIG_FILE}`;
-  if (!existsSync(filepath)) {
+  const filepath = findLocalConfigPath(projectRoot);
+  if (!filepath) {
     return null;
   }
   const raw = readYaml(filepath, {});
@@ -79,7 +99,8 @@ export function saveLocalConfig(config: LocalConfig, projectRoot: string = proce
 }
 
 export function getLocalConfigPath(projectRoot: string = process.cwd()): string {
-  return `${projectRoot}/${GREKT_DIR}/${LOCAL_CONFIG_FILE}`;
+  // Return existing config path if found, otherwise default to projectRoot
+  return findLocalConfigPath(projectRoot) ?? `${projectRoot}/${GREKT_DIR}/${LOCAL_CONFIG_FILE}`;
 }
 
 // Generate YAML with helpful comments for self-documentation


### PR DESCRIPTION
## Summary
- Add `findLocalConfigPath` helper that walks up directory tree to find `.grekt/config.yaml`
- Update `getLocalConfig` and `getLocalConfigPath` to use walk-up behavior
- Enables running `grekt publish` from nested directories (e.g., `artifacts/cli-experts`) and finding config in parent (`artifacts/.grekt/config.yaml`)

## Test plan
- [x] Existing tests pass (updated to use system temp dir to avoid finding parent configs)
- [x] New test verifies walk-up behavior finds config in parent directory

- ca