### PR TITLE
fix(init): auto-add @ prefix to author if missing

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -47,14 +47,11 @@ export const initCommand = new Command("init")
         },
       });
 
-      const author = await input({
-        message: "Author (e.g., @username):",
-        validate: (value) => {
-          if (!value.trim()) return "Author is required";
-          if (!value.startsWith("@")) return "Author must start with @";
-          return true;
-        },
+      const authorInput = await input({
+        message: "Author (e.g., grekt):",
+        validate: (value) => (value.trim() ? true : "Author is required"),
       });
+      const author = authorInput.startsWith("@") ? authorInput : `@${authorInput}`;
 
       const version = await input({
         message: "Version:",


### PR DESCRIPTION
## Summary

When initializing an artifact with `grekt init --artifact`, users can now enter their author name with or without the `@` prefix. The system automatically normalizes it.

## Changes

- Accept both `grekt` and `@grekt` as valid author input
- Auto-add `@` prefix if missing

## Example

```
? Author (e.g., grekt): grekt
# Results in author: @grekt
```