### PR TITLE
feat(prompts): add graceful exit handler for Ctrl+C

### DIFF
--- a/src/artifact/selector/selector.ts
+++ b/src/artifact/selector/selector.ts
@@ -1,4 +1,5 @@
 import { checkbox } from "@inquirer/prompts";
+import { withPromptHandler } from "#/shared/prompts/prompts";
 import type { ArtifactInfo } from "#/context";
 
 /**
@@ -15,54 +16,56 @@ export interface ComponentSelection {
  * Returns the paths of selected components.
  */
 export async function selectComponents(artifactInfo: ArtifactInfo): Promise<ComponentSelection> {
-  const choices: Array<{ name: string; value: { type: string; path: string }; checked: boolean }> = [];
+  return withPromptHandler(async () => {
+    const choices: Array<{ name: string; value: { type: string; path: string }; checked: boolean }> = [];
 
-  if (artifactInfo.agent) {
-    choices.push({
-      name: `agent: ${artifactInfo.agent.parsed.frontmatter["grk-name"]}`,
-      value: { type: "agent", path: artifactInfo.agent.path },
-      checked: true,
-    });
-  }
-
-  for (const skill of artifactInfo.skills) {
-    choices.push({
-      name: `skill: ${skill.parsed.frontmatter["grk-name"]}`,
-      value: { type: "skill", path: skill.path },
-      checked: true,
-    });
-  }
-
-  for (const cmd of artifactInfo.commands) {
-    choices.push({
-      name: `command: ${cmd.parsed.frontmatter["grk-name"]}`,
-      value: { type: "command", path: cmd.path },
-      checked: true,
-    });
-  }
-
-  const selected = await checkbox({
-    message: "Select components to install:",
-    choices,
-  });
-
-  const result: ComponentSelection = {
-    agent: undefined,
-    skills: [],
-    commands: [],
-  };
-
-  for (const item of selected) {
-    if (item.type === "agent") {
-      result.agent = item.path;
-    } else if (item.type === "skill") {
-      result.skills.push(item.path);
-    } else if (item.type === "command") {
-      result.commands.push(item.path);
+    if (artifactInfo.agent) {
+      choices.push({
+        name: `agent: ${artifactInfo.agent.parsed.frontmatter["grk-name"]}`,
+        value: { type: "agent", path: artifactInfo.agent.path },
+        checked: true,
+      });
     }
-  }
 
-  return result;
+    for (const skill of artifactInfo.skills) {
+      choices.push({
+        name: `skill: ${skill.parsed.frontmatter["grk-name"]}`,
+        value: { type: "skill", path: skill.path },
+        checked: true,
+      });
+    }
+
+    for (const cmd of artifactInfo.commands) {
+      choices.push({
+        name: `command: ${cmd.parsed.frontmatter["grk-name"]}`,
+        value: { type: "command", path: cmd.path },
+        checked: true,
+      });
+    }
+
+    const selected = await checkbox({
+      message: "Select components to install:",
+      choices,
+    });
+
+    const result: ComponentSelection = {
+      agent: undefined,
+      skills: [],
+      commands: [],
+    };
+
+    for (const item of selected) {
+      if (item.type === "agent") {
+        result.agent = item.path;
+      } else if (item.type === "skill") {
+        result.skills.push(item.path);
+      } else if (item.type === "command") {
+        result.commands.push(item.path);
+      }
+    }
+
+    return result;
+  });
 }
 
 /**

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -8,6 +8,7 @@ import { getPluginChoices, getDefaultTarget } from "#/sync/manager/manager";
 import { createEmptyIndex } from "#/artifact/index/index";
 import { GREKT_YAML, GREKT_DIR, ARTIFACTS_DIR, INDEX_FILE } from "#/config/paths/paths";
 import { success, info, warning, newline, log, colors } from "#/shared/ui/ui";
+import { withPromptHandler } from "#/shared/prompts/prompts";
 import type { CustomTarget, ProjectConfig } from "@grekt-labs/cli-engine";
 
 const OTHER_TARGET_VALUE = "__other__";
@@ -17,16 +18,17 @@ export const initCommand = new Command("init")
   .option("-y, --yes", "Skip prompts and use defaults")
   .option("-a, --artifact", "Initialize as publishable artifact (includes manifest fields)")
   .action(async (options: { yes?: boolean; artifact?: boolean }) => {
-    const projectRoot = process.cwd();
+    await withPromptHandler(async () => {
+      const projectRoot = process.cwd();
 
-    // Check if already initialized
-    if (isInitialized(projectRoot)) {
-      warning("grekt is already initialized in this directory");
-      return;
-    }
+      // Check if already initialized
+      if (isInitialized(projectRoot)) {
+        warning("grekt is already initialized in this directory");
+        return;
+      }
 
-    info("Initializing grekt...");
-    newline();
+      info("Initializing grekt...");
+      newline();
 
     // Manifest fields (for --artifact mode)
     let manifestFields: Partial<ProjectConfig> = {};
@@ -200,4 +202,5 @@ export const initCommand = new Command("init")
       info(`Sync targets: ${targets.join(", ")}`);
       info("Run 'grekt add <artifact>' to install your first artifact");
     }
+    });
   });

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -8,6 +8,7 @@ import { getSafeFilename } from "@grekt-labs/cli-engine";
 import { ARTIFACTS_DIR } from "#/config/paths/paths";
 import { generateArtifactIndex } from "#/artifact/index/index";
 import { success, error, info, log, newline, colors } from "#/shared/ui/ui";
+import { withPromptHandler } from "#/shared/prompts/prompts";
 
 // Claude target paths
 const CLAUDE_DIR = ".claude";
@@ -21,13 +22,14 @@ export const removeCommand = new Command("remove")
   .argument("<artifact>", "Artifact ID to remove (e.g., @grekt/code-reviewer)")
   .option("-f, --force", "Skip confirmation prompt")
   .action(async (artifactId: string, options: { force?: boolean }) => {
-    const projectRoot = process.cwd();
+    await withPromptHandler(async () => {
+      const projectRoot = process.cwd();
 
-    if (!isInitialized(projectRoot)) {
-      error("grekt is not initialized in this directory");
-      info("Run 'grekt init' first");
-      process.exit(1);
-    }
+      if (!isInitialized(projectRoot)) {
+        error("grekt is not initialized in this directory");
+        info("Run 'grekt init' first");
+        process.exit(1);
+      }
 
     const config = getConfig(projectRoot);
     const lockfile = getLockfile(projectRoot);
@@ -139,6 +141,7 @@ export const removeCommand = new Command("remove")
 
     newline();
     info("Run 'grekt sync' to update CLAUDE.md");
+    });
   });
 
 /**

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -4,6 +4,7 @@ import { isInitialized, getConfig, saveConfig } from "#/config/project/project";
 import { getLockfile } from "#/context";
 import { getPlugin, getAvailableTargets, getPluginChoices } from "#/sync/manager/manager";
 import { success, error, info, warning, log, newline, colors, spinner } from "#/shared/ui/ui";
+import { withPromptHandler } from "#/shared/prompts/prompts";
 import type { CustomTarget } from "@grekt-labs/cli-engine";
 
 const OTHER_TARGET_VALUE = "__other__";
@@ -15,13 +16,14 @@ export const syncCommand = new Command("sync")
   .option("-t, --target <targets>", "Comma-separated list of targets")
   .option("-n, --new", "Configure new sync targets interactively")
   .action(async (options: { dryRun?: boolean; force?: boolean; target?: string; new?: boolean }) => {
-    const projectRoot = process.cwd();
+    await withPromptHandler(async () => {
+      const projectRoot = process.cwd();
 
-    if (!isInitialized(projectRoot)) {
-      error("grekt is not initialized in this directory");
-      info("Run 'grekt init' first");
-      process.exit(1);
-    }
+      if (!isInitialized(projectRoot)) {
+        error("grekt is not initialized in this directory");
+        info("Run 'grekt init' first");
+        process.exit(1);
+      }
 
     let config = getConfig(projectRoot);
     const lockfile = getLockfile(projectRoot);
@@ -219,4 +221,5 @@ export const syncCommand = new Command("sync")
     } else {
       success("Sync complete!");
     }
+    });
   });

--- a/src/shared/prompts/prompts.test.ts
+++ b/src/shared/prompts/prompts.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "bun:test";
+import { ExitPromptError } from "@inquirer/core";
+
+// Mock ui module
+vi.mock("#/shared/ui/ui", () => ({
+  newline: vi.fn(),
+  info: vi.fn(),
+}));
+
+describe("withPromptHandler", () => {
+  const originalExit = process.exit;
+  let mockExit: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockExit = vi.fn();
+    process.exit = mockExit as unknown as typeof process.exit;
+  });
+
+  afterEach(() => {
+    process.exit = originalExit;
+    vi.clearAllMocks();
+  });
+
+  it("should return the result of the wrapped function", async () => {
+    const { withPromptHandler } = await import("./prompts");
+
+    const result = await withPromptHandler(async () => "success");
+
+    expect(result).toBe("success");
+  });
+
+  it("should handle ExitPromptError and exit gracefully", async () => {
+    const { withPromptHandler } = await import("./prompts");
+    const { newline, info } = await import("#/shared/ui/ui");
+
+    const fn = async () => {
+      throw new ExitPromptError("User force closed the prompt with SIGINT");
+    };
+
+    await withPromptHandler(fn);
+
+    expect(newline).toHaveBeenCalled();
+    expect(info).toHaveBeenCalledWith("Happy artifacting!");
+    expect(mockExit).toHaveBeenCalledWith(0);
+  });
+
+  it("should rethrow non-ExitPromptError errors", async () => {
+    const { withPromptHandler } = await import("./prompts");
+
+    const customError = new Error("Something else went wrong");
+    const fn = async () => {
+      throw customError;
+    };
+
+    await expect(withPromptHandler(fn)).rejects.toThrow("Something else went wrong");
+  });
+});

--- a/src/shared/prompts/prompts.ts
+++ b/src/shared/prompts/prompts.ts
@@ -1,0 +1,20 @@
+import { ExitPromptError } from "@inquirer/core";
+import { newline, info } from "#/shared/ui/ui";
+
+/**
+ * Wrap an async function that uses interactive prompts.
+ * Handles Ctrl+C gracefully with a friendly exit message.
+ */
+export async function withPromptHandler<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (error) {
+    if (error instanceof ExitPromptError) {
+      newline();
+      info("Happy artifacting!");
+      process.exit(0);
+      return undefined as T; // Unreachable, but needed for tests where process.exit is mocked
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `withPromptHandler` utility to handle Ctrl+C gracefully during interactive prompts
- Exits with friendly message "Happy artifacting!" instead of showing stack trace
- Applied to all interactive commands: init, sync, remove, and component selector

## Test plan
- [x] Unit tests added for withPromptHandler
- [ ] Manual test: run `grekt init` and press Ctrl+C during prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)