### PR TITLE
feat(publish): show detailed errors for invalid artifact files

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.971.0",
-    "@grekt-labs/cli-engine": "3.5.0",
+    "@grekt-labs/cli-engine": "3.6.0",
     "@inquirer/prompts": "^7.2.0",
     "@supabase/supabase-js": "^2.91.0",
     "chalk": "^5.4.1",

--- a/src/artifact/validation/validation.ts
+++ b/src/artifact/validation/validation.ts
@@ -4,11 +4,33 @@ import { parse } from "yaml";
 import { isInitialized } from "#/config/project/project";
 import { fs as cliFs } from "#/context";
 import { scanArtifact, ArtifactManifestSchema, isValidSemver } from "@grekt-labs/cli-engine";
+import type { InvalidFile } from "@grekt-labs/cli-engine";
 import type {
   ValidatedArtifact,
   ValidationOptions,
   ValidationResult,
 } from "./validation.types";
+
+function formatInvalidFileMessage(file: InvalidFile): string {
+  const prefix = `  ${file.path}:`;
+
+  switch (file.reason) {
+    case "no-frontmatter":
+      return `${prefix} missing frontmatter`;
+    case "invalid-frontmatter":
+      return `${prefix} invalid frontmatter format`;
+    case "missing-type":
+      return `${prefix} missing grk-type`;
+    case "missing-name":
+      return `${prefix} missing grk-name`;
+    case "missing-description":
+      return `${prefix} missing grk-description`;
+    case "invalid-json":
+      return `${prefix} invalid JSON`;
+    case "invalid-type-for-format":
+      return `${prefix} JSON files only support mcp or rule types`;
+  }
+}
 
 export function validateArtifact(
   artifactPath: string,
@@ -123,15 +145,23 @@ export function validateArtifact(
     scanned.rules.length;
 
   if (componentCount === 0) {
+    const details: string[] = [];
+
+    if (scanned.invalidFiles.length > 0) {
+      details.push("Invalid files found:");
+      for (const file of scanned.invalidFiles) {
+        details.push(formatInvalidFileMessage(file));
+      }
+    } else {
+      details.push("No .md or .json files found in artifact directory");
+    }
+
     return {
       success: false,
       error: {
         type: "no-components",
         message: "Artifact has no valid components",
-        details: [
-          "Add at least one agent, skill, command, mcp, or rule file",
-          "Files must have valid frontmatter (type, name, description)",
-        ],
+        details,
       },
     };
   }

--- a/src/artifact/validation/validation.types.ts
+++ b/src/artifact/validation/validation.types.ts
@@ -1,10 +1,10 @@
-import type { ArtifactManifest, ScannedArtifact } from "@grekt-labs/cli-engine";
+import type { ArtifactManifest, ArtifactInfo } from "@grekt-labs/cli-engine";
 
 export interface ValidatedArtifact {
   manifest: ArtifactManifest;
   artifactId: string;
   scope: string;
-  scanned: ScannedArtifact;
+  scanned: ArtifactInfo;
   componentCount: number;
   fullPath: string;
 }

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -47,6 +47,18 @@ function showKeywordsExample(): void {
   log(colors.dim("      - automation"));
 }
 
+function showFrontmatterExample(): void {
+  log("");
+  log(colors.dim("  Example frontmatter for .md files:"));
+  log(colors.dim("    ---"));
+  log(colors.dim("    grk-type: skill"));
+  log(colors.dim("    grk-name: My Skill"));
+  log(colors.dim("    grk-description: What this skill does"));
+  log(colors.dim("    ---"));
+  log("");
+  log(colors.dim("  Valid types: agent, skill, command, mcp, rule"));
+}
+
 export const publishCommand = new Command("publish")
   .description("Publish an artifact to a registry")
   .argument("[path]", "Path to artifact directory (default: current directory)", ".")
@@ -67,6 +79,9 @@ export const publishCommand = new Command("publish")
       }
       if (result.error.type === "keywords") {
         showKeywordsExample();
+      }
+      if (result.error.type === "no-components") {
+        showFrontmatterExample();
       }
       process.exit(1);
     }


### PR DESCRIPTION
## Summary
- Show which files are invalid when publish fails
- Display what's missing (grk-type, grk-name, grk-description)
- Show example frontmatter format

## Example output
```
✗ Artifact has no valid components
ℹ Invalid files found:
ℹ   agent.md: missing grk-type
ℹ   skill.md: missing grk-description

  Example frontmatter for .md files:
    ---
    grk-type: skill
    grk-name: My Skill
    grk-description: What this skill does
    ---

  Valid types: agent, skill, command, mcp, rule
```

## Dependencies
- Requires @grekt-labs/cli-engine 3.6.0 (grekt-labs/cli-engine#14)