### PR TITLE
fix: check synced files for core mode artifacts

### DIFF
--- a/src/artifact/check/check.ts
+++ b/src/artifact/check/check.ts
@@ -1,12 +1,28 @@
-import { existsSync } from "fs";
-import { basename } from "path";
-import { getLockfile } from "#/context";
+import { existsSync, readFileSync } from "fs";
+import { basename, join } from "path";
+import { getLockfile, getSafeFilename } from "#/context";
+import { getConfig } from "#/config/project/project";
+import { getSyncPaths, SYNC_CATEGORY_MAP } from "#/sync/manager/manager";
 import { ARTIFACTS_DIR } from "#/config/paths/paths";
 import { verifyIntegrity, getDirectorySize, formatBytes, estimateTokens } from "#/context";
 import { success, warning, log, newline, colors, symbols } from "#/shared/ui/ui";
-import type { Lockfile } from "@grekt-labs/cli-engine";
+import type { Lockfile, ProjectConfig, ArtifactMode } from "@grekt-labs/cli-engine";
 
 const CONTEXT_WARNING_THRESHOLD = 10 * 1024; // 10 KB
+
+function getArtifactMode(config: ProjectConfig, artifactId: string): ArtifactMode {
+  const entry = config.artifacts[artifactId];
+  if (!entry) return "lazy";
+  if (typeof entry === "string") return "lazy";
+  return entry.mode ?? "lazy";
+}
+
+function filesAreEqual(path1: string, path2: string): boolean {
+  if (!existsSync(path1) || !existsSync(path2)) return false;
+  const content1 = readFileSync(path1);
+  const content2 = readFileSync(path2);
+  return content1.equals(content2);
+}
 
 export interface CheckResult {
   artifactId: string;
@@ -74,6 +90,7 @@ function detectCollisions(lockfile: Lockfile): CollisionInfo[] {
  */
 export function runCheck(projectRoot: string): CheckSummary {
   const lockfile = getLockfile(projectRoot);
+  const config = getConfig(projectRoot);
   const artifactIds = Object.keys(lockfile.artifacts);
 
   const results: CheckResult[] = [];
@@ -108,6 +125,47 @@ export function runCheck(projectRoot: string): CheckSummary {
 
         for (const mod of integrity.modifiedFiles) {
           result.issues.push(`Modified: ${mod.path}`);
+        }
+      }
+    }
+
+    // Check synced files for CORE mode artifacts
+    const mode = getArtifactMode(config, artifactId);
+    if (mode === "core" && lockEntry && config.targets.length > 0) {
+      for (const target of config.targets) {
+        const syncPaths = getSyncPaths(target, config.customTargets);
+        if (!syncPaths) continue;
+
+        const checkSyncedFile = (sourcePath: string, targetDir: string, targetName: string): void => {
+          const targetPath = `${projectRoot}/${targetDir}/${targetName}`;
+          if (existsSync(targetPath)) {
+            if (!filesAreEqual(sourcePath, targetPath)) {
+              result.status = "drift";
+              result.issues.push(`Synced modified (${target}): ${targetDir}/${targetName}`);
+            }
+          } else {
+            result.status = "drift";
+            result.issues.push(`Synced missing (${target}): ${targetDir}/${targetName}`);
+          }
+        };
+
+        for (const [category, targetDir] of Object.entries(syncPaths)) {
+          const mapping = SYNC_CATEGORY_MAP[category as keyof typeof SYNC_CATEGORY_MAP];
+          if (!mapping) continue;
+
+          const items = lockEntry[mapping.lockKey as keyof typeof lockEntry];
+          if (!items) continue;
+
+          const paths = Array.isArray(items) ? items : [items];
+          for (const filePath of paths) {
+            if (typeof filePath !== "string") continue;
+
+            const targetName = mapping.isAgent
+              ? `${artifactId.replace("/", "-")}.md`
+              : getSafeFilename(artifactId, filePath);
+
+            checkSyncedFile(join(artifactDir, filePath), targetDir, targetName);
+          }
         }
       }
     }

--- a/src/sync/manager/manager.ts
+++ b/src/sync/manager/manager.ts
@@ -1,10 +1,61 @@
-import { dirname } from "path";
+import { dirname, join } from "path";
 import type { SyncPlugin } from "#/sync/sync.types";
-import type { CustomTarget } from "@grekt-labs/cli-engine";
+import type { CustomTarget, FolderPluginConfig, RulesOnlyPluginConfig } from "@grekt-labs/cli-engine";
 import { claudePlugin } from "#/sync/plugins/claude/claude";
 import { cursorPlugin } from "#/sync/plugins/cursor/cursor";
 import { opencodePlugin } from "#/sync/plugins/opencode/opencode";
 import { createRulesOnlyPlugin, createFolderPlugin, generateDefaultBlockContent } from "#/sync/base/base";
+
+export interface SyncPaths {
+  agents: string;
+  skills: string;
+  commands: string;
+}
+
+export interface CategoryMapping {
+  lockKey: string;
+  isAgent: boolean;
+}
+
+export const SYNC_CATEGORY_MAP: Record<keyof SyncPaths, CategoryMapping> = {
+  agents: { lockKey: "agent", isAgent: true },
+  skills: { lockKey: "skills", isAgent: false },
+  commands: { lockKey: "commands", isAgent: false },
+};
+
+type PluginConfig =
+  | { type: "folder"; config: FolderPluginConfig }
+  | { type: "rulesOnly"; config: RulesOnlyPluginConfig };
+
+const builtInConfigs: Record<string, PluginConfig> = {
+  claude: {
+    type: "folder",
+    config: {
+      id: "claude",
+      name: "Claude",
+      targetDir: ".claude",
+      contextEntryPoint: ".claude/CLAUDE.md",
+      generateRulesContent: generateDefaultBlockContent,
+    },
+  },
+  cursor: {
+    type: "rulesOnly",
+    config: {
+      id: "cursor",
+      name: "Cursor",
+      contextEntryPoint: ".cursorrules",
+      generateRulesContent: generateDefaultBlockContent,
+    },
+  },
+  opencode: {
+    type: "folder",
+    config: {
+      id: "opencode",
+      name: "OpenCode",
+      targetDir: ".opencode",
+    },
+  },
+};
 
 const builtInPlugins: Record<string, SyncPlugin> = {
   claude: claudePlugin,
@@ -118,6 +169,39 @@ export function validateTargets(targets: string[]): string[] {
     throw new Error(`Invalid targets: ${invalid.join(", ")}. Available: ${available.join(", ")}`);
   }
   return targets;
+}
+
+/**
+ * Get sync paths for a target (where files are copied to).
+ * Returns null if target doesn't copy files (RulesOnlyPlugin).
+ */
+export function getSyncPaths(target: string, customTargets?: Record<string, CustomTarget>): SyncPaths | null {
+  // Check built-in plugins
+  const builtIn = builtInConfigs[target];
+  if (builtIn) {
+    if (builtIn.type === "rulesOnly") return null;
+
+    const { targetDir, paths } = builtIn.config;
+    return {
+      agents: paths?.agent ?? join(targetDir, "agents"),
+      skills: paths?.skill ?? join(targetDir, "skills"),
+      commands: paths?.command ?? join(targetDir, "commands"),
+    };
+  }
+
+  // Check custom targets
+  const customTarget = customTargets?.[target];
+  if (!customTarget) return null;
+
+  // Custom targets without paths are RulesOnlyPlugin
+  if (!customTarget.paths) return null;
+
+  const baseDir = dirname(customTarget.contextEntryPoint);
+  return {
+    agents: customTarget.paths.agent ?? join(baseDir, "agents"),
+    skills: customTarget.paths.skill ?? join(baseDir, "skills"),
+    commands: customTarget.paths.command ?? join(baseDir, "commands"),
+  };
 }
 
 // Re-export types


### PR DESCRIPTION
## Summary
- Add verification of files copied to sync targets (e.g., `.claude/skills/`)
- Detects drift when synced files differ from source or are missing
- Centralizes sync paths and category mapping in manager for reuse

## Test plan
- [ ] Install artifact with `--core` flag
- [ ] Modify a synced file in `.claude/skills/`
- [ ] Run `grekt check` and verify drift is detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)