### PR TITLE
fix: normalize author scope to prevent double @ in artifactId

### DIFF
--- a/src/artifact/validation/validation.ts
+++ b/src/artifact/validation/validation.ts
@@ -166,8 +166,9 @@ export function validateArtifact(
     };
   }
 
-  const artifactId = `@${manifest.author}/${manifest.name}`;
-  const scope = `@${manifest.author}`;
+  const authorName = manifest.author.startsWith("@") ? manifest.author.slice(1) : manifest.author;
+  const artifactId = `@${authorName}/${manifest.name}`;
+  const scope = `@${authorName}`;
 
   return {
     success: true,

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -57,7 +57,7 @@ export const initCommand = new Command("init")
         message: "Author (e.g., grekt):",
         validate: (value) => (value.trim() ? true : "Author is required"),
       });
-      const author = authorInput.startsWith("@") ? authorInput : `@${authorInput}`;
+      const author = authorInput.startsWith("@") ? authorInput.slice(1) : authorInput;
 
       const version = await input({
         message: "Version:",
@@ -174,7 +174,7 @@ export const initCommand = new Command("init")
     if (options.artifact) {
       success("Artifact initialized successfully!");
       newline();
-      info(`Artifact: ${manifestFields.author}/${manifestFields.name}@${manifestFields.version}`);
+      info(`Artifact: @${manifestFields.author}/${manifestFields.name}@${manifestFields.version}`);
       info("Run 'grekt publish' when ready to publish");
     } else {
       success("grekt initialized successfully!");


### PR DESCRIPTION
## Summary
- Strip leading `@` from author field when constructing artifactId
- Handles both old manifests with `@author` and new ones without
- Updates `init` command to store author without `@` prefix

## Test plan
- [ ] Publish artifact with `author: "@grekt"` in manifest
- [ ] Verify output shows `@grekt/name` (not `@@grekt/name`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)