### PR TITLE
fix: prevent command injection in tar operations

### DIFF
--- a/src/artifact/tarball/tarball.ts
+++ b/src/artifact/tarball/tarball.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { existsSync, mkdirSync } from "fs";
 import { basename, dirname, join } from "path";
 
@@ -36,7 +36,7 @@ export function createTarball(options: CreateTarballOptions): TarballResult {
   const parentDir = dirname(artifactPath);
 
   try {
-    execSync(`tar -czf ${outputPath} -C ${parentDir} ${artifactDir}`, {
+    execFileSync("tar", ["-czf", outputPath, "-C", parentDir, artifactDir], {
       stdio: "pipe",
     });
 

--- a/src/registry/api-client/api-client.ts
+++ b/src/registry/api-client/api-client.ts
@@ -1,5 +1,5 @@
-import { mkdirSync, writeFileSync } from "fs";
-import { execSync } from "child_process";
+import { mkdirSync, writeFileSync, rmSync } from "fs";
+import { execFileSync } from "child_process";
 import type { ArtifactMetadata } from "@grekt-labs/cli-engine";
 import { sortVersionsDesc, getHighestVersion } from "@grekt-labs/cli-engine";
 import { getSupabaseClient, getSession, SUPABASE_URL } from "#/auth/session/session";
@@ -157,10 +157,10 @@ export class RegistryClient {
       writeFileSync(tempTarball, Buffer.from(buffer));
 
       mkdirSync(targetDir, { recursive: true });
-      execSync(`tar -xzf ${tempTarball} -C ${targetDir} --strip-components=1`, {
+      execFileSync("tar", ["-xzf", tempTarball, "-C", targetDir, "--strip-components=1"], {
         stdio: "pipe",
       });
-      execSync(`rm -f ${tempTarball}`, { stdio: "pipe" });
+      rmSync(tempTarball, { force: true });
 
       return {
         success: true,

--- a/src/registry/download/download.ts
+++ b/src/registry/download/download.ts
@@ -1,5 +1,5 @@
 import { mkdirSync, writeFileSync, existsSync, rmSync } from "fs";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -56,8 +56,11 @@ export async function downloadAndExtractTarball(
     mkdirSync(targetDir, { recursive: true });
 
     // Extract tarball
-    const stripArg = stripComponents > 0 ? `--strip-components=${stripComponents}` : "";
-    execSync(`tar -xzf ${tempTarball} -C ${targetDir} ${stripArg}`, {
+    const tarArgs = ["-xzf", tempTarball, "-C", targetDir];
+    if (stripComponents > 0) {
+      tarArgs.push(`--strip-components=${stripComponents}`);
+    }
+    execFileSync("tar", tarArgs, {
       stdio: "pipe",
     });
 


### PR DESCRIPTION
## Summary
- Use `execFileSync` instead of `execSync` to prevent shell injection
- Pass arguments as arrays instead of interpolated strings
- Replace `execSync rm` with `rmSync` for cleanup

## Test plan
- [ ] Verify tar operations still work correctly
- [ ] Test with artifact IDs containing special characters

Closes #41