### PR TITLE
fix: prevent path traversal in artifact IDs

### DIFF
--- a/src/artifact/validation/validation.ts
+++ b/src/artifact/validation/validation.ts
@@ -11,6 +11,40 @@ import type {
   ValidationResult,
 } from "./validation.types";
 
+/**
+ * Validate that an artifact ID is safe for filesystem operations.
+ * Prevents path traversal attacks by rejecting IDs with dangerous patterns.
+ * Returns true if safe, false otherwise.
+ */
+export function isSafeArtifactId(artifactId: string): boolean {
+  // Reject path traversal attempts
+  if (artifactId.includes("..")) {
+    return false;
+  }
+
+  // Reject absolute paths
+  if (artifactId.startsWith("/") || artifactId.startsWith("\\")) {
+    return false;
+  }
+
+  // Reject null bytes (can truncate paths in some systems)
+  if (artifactId.includes("\0")) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Assert that an artifact ID is safe for filesystem operations.
+ * Throws an error if the ID contains dangerous patterns.
+ */
+export function assertSafeArtifactId(artifactId: string): void {
+  if (!isSafeArtifactId(artifactId)) {
+    throw new Error(`Invalid artifact ID: "${artifactId}" contains unsafe path characters`);
+  }
+}
+
 function formatInvalidFileMessage(file: InvalidFile): string {
   const prefix = `  ${file.path}:`;
 

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -11,6 +11,7 @@ import { selectComponents, isEmptySelection, isFullSelection, createEmptySelecti
 import { removeUnselectedFiles } from "#/artifact/component-manager/component-manager";
 import { runCheck, displayCompactCheckResults } from "#/artifact/check/check";
 import { generateArtifactIndex } from "#/artifact/index/index";
+import { assertSafeArtifactId } from "#/artifact/validation/validation";
 import { success, error, info, log, warning, newline, colors, spinner } from "#/shared/ui/ui";
 import { compareSemver, CATEGORIES, type Category } from "@grekt-labs/cli-engine";
 
@@ -77,6 +78,15 @@ export const addCommand = new Command("add")
     }
 
     const resolvedArtifactId = getArtifactId(artifactInfo.manifest.author, artifactInfo.manifest.name);
+
+    // Validate artifact ID to prevent path traversal
+    try {
+      assertSafeArtifactId(resolvedArtifactId);
+    } catch {
+      rmSync(tempDir, { recursive: true, force: true });
+      error("Invalid artifact: manifest contains unsafe characters in author or name");
+      process.exit(1);
+    }
 
     // Now we know the artifact ID, create final target directory
     const targetDir = `${projectRoot}/${ARTIFACTS_DIR}/${resolvedArtifactId}`;

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -8,6 +8,7 @@ import { downloadAndExtractTarball } from "#/registry/download/download";
 import { verifyIntegrity } from "#/context";
 import { runCheck, displayCompactCheckResults } from "#/artifact/check/check";
 import { generateArtifactIndex } from "#/artifact/index/index";
+import { isSafeArtifactId } from "#/artifact/validation/validation";
 import { success, error, info, warning, log, newline, colors, spinner } from "#/shared/ui/ui";
 
 export const installCommand = new Command("install")
@@ -53,6 +54,13 @@ export const installCommand = new Command("install")
     let failed = 0;
 
     for (const [artifactId, entry] of artifacts) {
+      // Validate artifact ID to prevent path traversal from corrupted lockfile
+      if (!isSafeArtifactId(artifactId)) {
+        error(`Skipping unsafe artifact ID: ${artifactId}`);
+        failed++;
+        continue;
+      }
+
       const targetDir = `${projectRoot}/${ARTIFACTS_DIR}/${artifactId}`;
 
       // Check if already installed

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -7,6 +7,7 @@ import { getLockfile, saveLockfile } from "#/context";
 import { getSafeFilename, CATEGORIES, CATEGORY_CONFIG, type Category } from "@grekt-labs/cli-engine";
 import { ARTIFACTS_DIR } from "#/config/paths/paths";
 import { generateArtifactIndex } from "#/artifact/index/index";
+import { isSafeArtifactId } from "#/artifact/validation/validation";
 import { success, error, info, log, newline, colors } from "#/shared/ui/ui";
 import { withPromptHandler } from "#/shared/prompts/prompts";
 
@@ -34,6 +35,12 @@ export const removeCommand = new Command("remove")
         info("Run 'grekt init' first");
         process.exit(1);
       }
+
+    // Validate artifact ID to prevent path traversal
+    if (!isSafeArtifactId(artifactId)) {
+      error("Invalid artifact ID: contains unsafe path characters");
+      process.exit(1);
+    }
 
     const config = getConfig(projectRoot);
     const lockfile = getLockfile(projectRoot);


### PR DESCRIPTION
## Summary
- Add `isSafeArtifactId` and `assertSafeArtifactId` validation functions
- Reject artifact IDs containing `..`, absolute paths, or null bytes
- Applied to add, remove, and install commands

## Test plan
- [ ] Test add with artifact containing `..` in manifest author/name
- [ ] Test remove with `../../../etc/passwd` as argument
- [ ] Test install with corrupted lockfile containing traversal paths

Closes #42