### PR TITLE
fix: use cryptographic random for temp file names

### DIFF
--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { randomUUID } from "crypto";
 import { existsSync, mkdirSync, rmSync, renameSync } from "fs";
 import { isInitialized, getConfig, saveConfig } from "#/config/project/project";
 import { getLockfile, saveLockfile } from "#/context";
@@ -35,7 +36,7 @@ export const addCommand = new Command("add")
     const displayName = getSourceDisplayName(source);
 
     // For git sources, use temp dir first, then rename after we know the artifact ID
-    const tempDir = `${projectRoot}/${ARTIFACTS_DIR}/.tmp-${Date.now()}`;
+    const tempDir = `${projectRoot}/${ARTIFACTS_DIR}/.tmp-${randomUUID()}`;
 
     const spin = spinner(`Downloading ${displayName}...`);
     spin.start();

--- a/src/registry/api-client/api-client.ts
+++ b/src/registry/api-client/api-client.ts
@@ -1,5 +1,6 @@
 import { mkdirSync, writeFileSync, rmSync } from "fs";
 import { execFileSync } from "child_process";
+import { randomUUID } from "crypto";
 import type { ArtifactMetadata } from "@grekt-labs/cli-engine";
 import { sortVersionsDesc, getHighestVersion } from "@grekt-labs/cli-engine";
 import { getSupabaseClient, getSession, SUPABASE_URL } from "#/auth/session/session";
@@ -153,7 +154,7 @@ export class RegistryClient {
       }
 
       const buffer = await response.arrayBuffer();
-      const tempTarball = `/tmp/grekt-${Date.now()}.tar.gz`;
+      const tempTarball = `/tmp/grekt-${randomUUID()}.tar.gz`;
       writeFileSync(tempTarball, Buffer.from(buffer));
 
       mkdirSync(targetDir, { recursive: true });

--- a/src/registry/download/download.ts
+++ b/src/registry/download/download.ts
@@ -1,5 +1,6 @@
 import { mkdirSync, writeFileSync, existsSync, rmSync } from "fs";
 import { execFileSync } from "child_process";
+import { randomUUID } from "crypto";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -34,7 +35,7 @@ export async function downloadAndExtractTarball(
     ...headers,
   };
 
-  const tempTarball = join(tmpdir(), `grekt-${Date.now()}.tar.gz`);
+  const tempTarball = join(tmpdir(), `grekt-${randomUUID()}.tar.gz`);
 
   try {
     const response = await fetch(url, {


### PR DESCRIPTION
## Summary
- Replace `Date.now()` with `crypto.randomUUID()` for temp files
- Prevents symlink attacks where attacker pre-creates symlinks with predictable names

## Files changed
- download.ts
- api-client.ts
- add.ts

## Test plan
- [ ] Verify temp files are created with random UUIDs
- [ ] Verify cleanup still works correctly

Closes #43