### PR TITLE
fix: handle Promise.all errors with spinner cleanup

### DIFF
--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -22,10 +22,19 @@ export const infoCommand = new Command("info")
     const spin = spinner("Fetching artifact info...");
     spin.start();
 
-    const [metadata, versions] = await Promise.all([
-      getArtifactMetadata(credentials, artifactId),
-      listVersions(credentials, artifactId),
-    ]);
+    let metadata: Awaited<ReturnType<typeof getArtifactMetadata>> = null;
+    let versions: Awaited<ReturnType<typeof listVersions>> = [];
+
+    try {
+      [metadata, versions] = await Promise.all([
+        getArtifactMetadata(credentials, artifactId),
+        listVersions(credentials, artifactId),
+      ]);
+    } catch (err) {
+      spin.stop();
+      error(`Failed to fetch artifact info: ${err instanceof Error ? err.message : "Unknown error"}`);
+      process.exit(1);
+    }
 
     spin.stop();
 

--- a/src/commands/versions.ts
+++ b/src/commands/versions.ts
@@ -22,10 +22,19 @@ export const versionsCommand = new Command("versions")
     const spin = spinner("Fetching versions...");
     spin.start();
 
-    const [metadata, versions] = await Promise.all([
-      getArtifactMetadata(credentials, artifactId),
-      listVersions(credentials, artifactId),
-    ]);
+    let metadata: Awaited<ReturnType<typeof getArtifactMetadata>> = null;
+    let versions: Awaited<ReturnType<typeof listVersions>> = [];
+
+    try {
+      [metadata, versions] = await Promise.all([
+        getArtifactMetadata(credentials, artifactId),
+        listVersions(credentials, artifactId),
+      ]);
+    } catch (err) {
+      spin.stop();
+      error(`Failed to fetch versions: ${err instanceof Error ? err.message : "Unknown error"}`);
+      process.exit(1);
+    }
 
     spin.stop();
 


### PR DESCRIPTION
## Summary
- Wrap `Promise.all` in try-catch in info and versions commands
- Ensure spinner stops before showing error message
- Display meaningful error message on failure

## Test plan
- [ ] Test info command with network error
- [ ] Test versions command with network error
- [ ] Verify spinner stops cleanly on error

Closes #44