### PR TITLE
feat: improve error messages and fix install auth

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "grekt",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.971.0",
-        "@grekt-labs/cli-engine": "^4.0.0",
+        "@grekt-labs/cli-engine": "4.1.0",
         "@inquirer/prompts": "^7.2.0",
         "@supabase/supabase-js": "^2.91.0",
         "chalk": "^5.4.1",
@@ -123,7 +123,7 @@
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
-    "@grekt-labs/cli-engine": ["@grekt-labs/cli-engine@4.0.0", "https://npm.pkg.github.com/download/@grekt-labs/cli-engine/4.0.0/4aaa11224587c8a72ec0a5e0d982053d2ea4098b", { "dependencies": { "gray-matter": "^4.0.3", "semver": "^7.7.3", "yaml": "^2.6.1", "zod": "^3.24.1" } }, "sha512-eC3AXH1nTA0jiRqc3Q3MO0nL706mN/Mn6MYEHihDy+PEq5y4NcNjNxyKkS6LijpCZL6eb/hvBz5P1PiRnx8KJg=="],
+    "@grekt-labs/cli-engine": ["@grekt-labs/cli-engine@4.1.0", "https://npm.pkg.github.com/download/@grekt-labs/cli-engine/4.1.0/12dadec2c2ba55c35e9dbef8a1fbb6f47c8ea948", { "dependencies": { "gray-matter": "^4.0.3", "semver": "^7.7.3", "yaml": "^2.6.1", "zod": "^3.24.1" } }, "sha512-pmfV3tRYKMCNEJOHw5//oKeALdzz9uBvPwh4rK/9pjTg9ODkM8xg6sgWjtlAmL0PT5+/Wdpa/P+Jt+Fdym/yyA=="],
 
     "@inquirer/ansi": ["@inquirer/ansi@1.0.2", "", {}, "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="],
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.971.0",
-    "@grekt-labs/cli-engine": "^4.0.0",
+    "@grekt-labs/cli-engine": "4.1.0",
     "@inquirer/prompts": "^7.2.0",
     "@supabase/supabase-js": "^2.91.0",
     "chalk": "^5.4.1",

--- a/src/artifact/validation/validation.ts
+++ b/src/artifact/validation/validation.ts
@@ -48,6 +48,12 @@ export function assertSafeArtifactId(artifactId: string): void {
 function formatInvalidFileMessage(file: InvalidFile): string {
   const prefix = `  ${file.path}:`;
 
+  // If we have detailed error info, use it
+  if (file.details) {
+    return `${prefix} ${file.details}`;
+  }
+
+  // Fallback to generic messages
   switch (file.reason) {
     case "no-frontmatter":
       return `${prefix} missing frontmatter`;

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,15 +1,43 @@
 import { Command } from "commander";
 import { existsSync, mkdirSync, rmSync } from "fs";
-import { isInitialized, getConfig } from "#/config/project/project";
+import { isInitialized, getConfig, getLocalConfig } from "#/config/project/project";
 import { getLockfile, lockfileExists } from "#/context";
 import { ARTIFACTS_DIR } from "#/config/paths/paths";
-import { parseSource, downloadFromSource } from "#/registry/sources/sources";
+import { parseSource, downloadFromSource, getSourceToken } from "#/registry/sources/sources";
 import { downloadAndExtractTarball } from "#/registry/download/download";
 import { verifyIntegrity } from "#/context";
 import { runCheck, displayCompactCheckResults } from "#/artifact/check/check";
 import { generateArtifactIndex } from "#/artifact/index/index";
 import { isSafeArtifactId } from "#/artifact/validation/validation";
+import { resolveRegistry } from "#/registry/factory/factory";
+import { parseArtifactId, getGitLabHeaders, getGitHubHeaders } from "@grekt-labs/cli-engine";
 import { success, error, info, warning, log, newline, colors, spinner } from "#/shared/ui/ui";
+
+/**
+ * Get authentication headers for downloading an artifact.
+ * Resolves the registry type from the artifact scope and returns appropriate headers.
+ */
+function getHeadersForArtifact(artifactId: string, projectRoot: string): Record<string, string> {
+  try {
+    const { scope } = parseArtifactId(artifactId);
+    const localConfig = getLocalConfig(projectRoot);
+    const registry = resolveRegistry(scope, localConfig, projectRoot);
+
+    if (registry.type === "gitlab") {
+      const token = registry.token || process.env.GITLAB_TOKEN || process.env.GL_TOKEN;
+      return getGitLabHeaders(token);
+    }
+
+    if (registry.type === "github") {
+      const token = registry.token || process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+      return getGitHubHeaders(token);
+    }
+
+    return {};
+  } catch {
+    return {};
+  }
+}
 
 export const installCommand = new Command("install")
   .alias("i")
@@ -88,7 +116,9 @@ export const installCommand = new Command("install")
 
       // Use resolved URL if available (strict mode - no recalculation)
       if (entry.resolved) {
-        const result = await downloadAndExtractTarball(entry.resolved, targetDir);
+        // Get auth headers for the resolved URL based on registry type
+        const headers = getHeadersForArtifact(artifactId, projectRoot);
+        const result = await downloadAndExtractTarball(entry.resolved, targetDir, { headers });
         downloadSuccess = result.success;
       } else {
         // Fallback for old lockfiles without resolved

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -11,6 +11,7 @@ import { isApiAuthenticated } from "#/registry/publishers/api-publisher";
 import type { PublishContext } from "#/registry/publishers/publisher.types";
 import { createTarball, removeTarball } from "#/artifact/tarball/tarball";
 import { validateArtifact } from "#/artifact/validation/validation";
+import { CATEGORIES } from "@grekt-labs/cli-engine";
 import { success, error, info, log, colors, spinner } from "#/shared/ui/ui";
 
 const MIN_KEYWORDS = 3;
@@ -51,12 +52,12 @@ function showFrontmatterExample(): void {
   log("");
   log(colors.dim("  Example frontmatter for .md files:"));
   log(colors.dim("    ---"));
-  log(colors.dim("    grk-type: skill"));
-  log(colors.dim("    grk-name: My Skill"));
-  log(colors.dim("    grk-description: What this skill does"));
+  log(colors.dim(`    grk-type: ${CATEGORIES[0]}`));
+  log(colors.dim("    grk-name: My Component"));
+  log(colors.dim("    grk-description: What this component does"));
   log(colors.dim("    ---"));
   log("");
-  log(colors.dim("  Valid types: agent, skill, command, mcp, rule"));
+  log(colors.dim(`  Valid types: ${CATEGORIES.join(", ")}`));
 }
 
 export const publishCommand = new Command("publish")


### PR DESCRIPTION
## Summary

### Install auth fix
- Pass authentication headers when downloading from resolved URLs
- Resolve registry type from artifact scope to get correct token
- Fixes 401 errors when installing from GitLab registries

### Better error messages
- Display detailed frontmatter validation errors from cli-engine 4.1.0
- Use `CATEGORIES` dynamically in publish examples instead of hardcoding
- Show exact values vs expected for invalid `grk-type`

### Example error output

Before:
```
agents/test.md: invalid frontmatter format
```

After:
```
agents/test.md: grk-type: got 'agent', expected one of: agents, skills, commands, mcps, rules
```

## Test plan

- [x] All tests pass
- [x] Tested install with GitLab registry (no more 401)
- [x] Tested publish with invalid frontmatter (detailed errors shown)