### PR TITLE
feat(install): show frontmatter validation errors on integrity failure

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -10,7 +10,8 @@ import { runCheck, displayCompactCheckResults } from "#/artifact/check/check";
 import { generateArtifactIndex } from "#/artifact/index/index";
 import { isSafeArtifactId } from "#/artifact/validation/validation";
 import { resolveRegistry } from "#/registry/factory/factory";
-import { parseArtifactId, getGitLabHeaders, getGitHubHeaders } from "@grekt-labs/cli-engine";
+import { parseArtifactId, getGitLabHeaders, getGitHubHeaders, scanArtifact } from "@grekt-labs/cli-engine";
+import { fs as cliFs } from "#/context";
 import { success, error, info, warning, log, newline, colors, spinner } from "#/shared/ui/ui";
 
 /**
@@ -149,13 +150,27 @@ export const installCommand = new Command("install")
 
       if (!integrity.valid) {
         spin.stop();
+
+        // Scan for frontmatter errors before deleting
+        const scanned = scanArtifact(cliFs, targetDir);
+        const hasValidationErrors = scanned && scanned.invalidFiles.length > 0;
+
         rmSync(targetDir, { recursive: true, force: true });
         error(`Integrity check failed for ${artifactId}`);
+
+        // Show frontmatter validation errors if any
+        if (hasValidationErrors) {
+          log(colors.dim("  Validation errors:"));
+          for (const file of scanned.invalidFiles) {
+            const detail = file.details || file.reason;
+            log(`    ${file.path}: ${detail}`);
+          }
+        }
 
         if (integrity.missingFiles.length > 0) {
           log(`  ${colors.dim("missing:")} ${integrity.missingFiles.join(", ")}`);
         }
-        if (integrity.modifiedFiles.length > 0) {
+        if (integrity.modifiedFiles.length > 0 && !hasValidationErrors) {
           log(`  ${colors.dim("modified:")} ${integrity.modifiedFiles.map((f) => f.path).join(", ")}`);
         }
 


### PR DESCRIPTION
## Summary

When `grekt install` fails due to integrity mismatch, scan the downloaded files for frontmatter validation errors and display them.

## Before

```
✗ Integrity check failed for @grekt/tools
  modified: agents/assistant.md, skills/registry-config.md, ...
```

## After

```
✗ Integrity check failed for @grekt/tools
  Validation errors:
    agents/assistant.md: grk-type: got 'agent', expected one of: agents, skills, commands, mcps, rules
    skills/registry-config.md: missing grk-type
    ...
```

## Test plan

- [x] All tests pass
- [x] Tested with artifact having invalid frontmatter