### PR TITLE
feat(claude): sync skills as folders for Claude Code format

### DIFF
--- a/src/sync/base/base.ts
+++ b/src/sync/base/base.ts
@@ -95,8 +95,11 @@ export function createFolderPlugin(config: FolderPluginConfig): SyncPlugin {
     result.updated.push(contextEntryPoint);
   }
 
-  // Get target filename for a component
-  function getTargetName(artifactId: string, _category: Category, filePath: string): string {
+  function getTargetPath(artifactId: string, category: Category, filePath: string): string {
+    if (config.getTargetPath) {
+      const customPath = config.getTargetPath(artifactId, category, filePath);
+      if (customPath) return customPath;
+    }
     return getSafeFilename(artifactId, filePath);
   }
 
@@ -148,7 +151,7 @@ export function createFolderPlugin(config: FolderPluginConfig): SyncPlugin {
 
           for (const filePath of files) {
             const source = join(artifactDir, filePath);
-            const targetName = getTargetName(artifactId, category, filePath);
+            const targetName = getTargetPath(artifactId, category, filePath);
             const target = `${projectRoot}/${categoryDir}/${targetName}`;
 
             if (existsSync(source)) {
@@ -194,7 +197,7 @@ export function createFolderPlugin(config: FolderPluginConfig): SyncPlugin {
 
           for (const filePath of files) {
             const source = join(artifactDir, filePath);
-            const targetName = getTargetName(artifactId, category, filePath);
+            const targetName = getTargetPath(artifactId, category, filePath);
             const target = `${projectRoot}/${categoryDir}/${targetName}`;
 
             if (!existsSync(source)) {

--- a/src/sync/plugins/claude/claude.ts
+++ b/src/sync/plugins/claude/claude.ts
@@ -1,7 +1,15 @@
+import { basename } from "path";
 import { createFolderPlugin, generateDefaultBlockContent } from "#/sync/base/base";
+import { toSafeName } from "@grekt-labs/cli-engine";
 
 const TARGET_DIR = ".claude";
 const CONTEXT_ENTRY_POINT = `${TARGET_DIR}/CLAUDE.md`;
+
+function getSkillFolderName(artifactId: string, filePath: string): string {
+  const safeName = toSafeName(artifactId);
+  const skillName = basename(filePath, ".md");
+  return `${safeName}-${skillName}`;
+}
 
 export const claudePlugin = createFolderPlugin({
   id: "claude",
@@ -9,6 +17,13 @@ export const claudePlugin = createFolderPlugin({
   targetDir: TARGET_DIR,
   contextEntryPoint: CONTEXT_ENTRY_POINT,
   generateRulesContent: generateDefaultBlockContent,
+  getTargetPath: (artifactId, category, filePath) => {
+    if (category === "skills") {
+      const folderName = getSkillFolderName(artifactId, filePath);
+      return `${folderName}/SKILL.md`;
+    }
+    return null;
+  },
 });
 
 export default claudePlugin;


### PR DESCRIPTION
## Summary
- Skills now sync to `skills/{name}/SKILL.md` instead of flat files
- Implements Claude Code's expected skill folder structure
- Uses new `getTargetPath` hook from cli-engine

## Test plan
- [x] All existing tests pass