### PR TITLE
feat: improve CLI error messages for missing arguments

### DIFF
--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -19,10 +19,18 @@ import { compareSemver, CATEGORIES, type Category } from "@grekt-labs/cli-engine
 
 export const addCommand = new Command("add")
   .description("Add an artifact from registry, GitHub, or GitLab")
-  .argument("<source>", "Artifact source (e.g., @grekt/code-reviewer, github:user/repo, gitlab:host/user/repo)")
+  .argument("[source]", "Artifact source (e.g., @grekt/code-reviewer, github:user/repo, gitlab:host/user/repo)")
   .option("-c, --choose", "Choose which components to install")
   .option("--core", "Mark artifact as CORE (copied to target on sync, not just indexed)")
-  .action(async (sourceArg: string, options: { choose?: boolean; core?: boolean }) => {
+  .action(async (sourceArg: string | undefined, options: { choose?: boolean; core?: boolean }) => {
+    if (!sourceArg) {
+      error("Source required. Examples:");
+      info("  grekt add @scope/artifact");
+      info("  grekt add github:user/repo");
+      info("  grekt add gitlab:host/user/repo");
+      process.exit(1);
+    }
+
     const projectRoot = process.cwd();
 
     if (!isInitialized(projectRoot)) {

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -84,12 +84,12 @@ const registryCommand = configCommand
   .description("Manage registry backends for scoped artifacts");
 
 registryCommand
-  .command("set <scope>")
+  .command("set [scope]")
   .description("Configure a registry for a scope (e.g., @myteam)")
   .action(setRegistryInteractive);
 
 registryCommand
-  .command("unset <scope>")
+  .command("unset [scope]")
   .description("Remove registry configuration for a scope")
   .action(unsetRegistry);
 
@@ -104,7 +104,7 @@ tokenCommand
   .action(setTokenInteractive);
 
 tokenCommand
-  .command("unset <host>")
+  .command("unset [host]")
   .description("Remove token for a git host")
   .action(unsetToken);
 

--- a/src/commands/config/registry/registry.ts
+++ b/src/commands/config/registry/registry.ts
@@ -2,10 +2,16 @@ import { select } from "@inquirer/prompts";
 import { registryProviders, promptRepoToken } from "./providers";
 import { setRegistry, removeRegistry, setToken, removeToken } from "#/config/project/project";
 import { withPromptHandler } from "#/shared/prompts/prompts";
-import { success, error, colors } from "#/shared/ui/ui";
+import { success, error, info, colors } from "#/shared/ui/ui";
 import type { RegistryEntry } from "#/registry/registry.types";
 
-export async function setRegistryInteractive(scope: string): Promise<void> {
+export async function setRegistryInteractive(scope: string | undefined): Promise<void> {
+  if (!scope) {
+    error("Scope required. Usage:");
+    info("  grekt config registry set @myteam");
+    process.exit(1);
+  }
+
   if (!scope.startsWith("@")) {
     error("Scope must start with @");
     process.exit(1);
@@ -23,7 +29,13 @@ export async function setRegistryInteractive(scope: string): Promise<void> {
   });
 }
 
-export async function unsetRegistry(scope: string): Promise<void> {
+export async function unsetRegistry(scope: string | undefined): Promise<void> {
+  if (!scope) {
+    error("Scope required. Usage:");
+    info("  grekt config registry unset @myteam");
+    process.exit(1);
+  }
+
   if (!scope.startsWith("@")) {
     error("Scope must start with @");
     process.exit(1);
@@ -40,7 +52,14 @@ export async function setTokenInteractive(): Promise<void> {
   });
 }
 
-export async function unsetToken(host: string): Promise<void> {
+export async function unsetToken(host: string | undefined): Promise<void> {
+  if (!host) {
+    error("Host required. Usage:");
+    info("  grekt config token unset github.com");
+    info("  grekt config token unset gitlab.company.com");
+    process.exit(1);
+  }
+
   removeToken(host);
   success(`Token for ${colors.highlight(host)} removed`);
 }

--- a/src/commands/deprecate.ts
+++ b/src/commands/deprecate.ts
@@ -34,11 +34,18 @@ interface DeprecateOptions {
 
 export const deprecateCommand = new Command("deprecate")
   .description("Deprecate an artifact version (API and S3 only, not supported for GitLab/GitHub)")
-  .argument("<artifact@version>", "Artifact and version to deprecate (e.g., @author/name@1.0.0)")
+  .argument("[artifact@version]", "Artifact and version to deprecate (e.g., @author/name@1.0.0)")
   .option("-m, --message <message>", "Deprecation message", "This version is deprecated")
   .option("--s3", "Use S3-compatible storage (legacy mode, env vars only)")
-  .action(async (artifactVersion: string, options: DeprecateOptions) => {
+  .action(async (artifactVersion: string | undefined, options: DeprecateOptions) => {
     const projectRoot = process.cwd();
+
+    if (!artifactVersion) {
+      error("Artifact and version required. Usage:");
+      info("  grekt deprecate @author/name@1.0.0");
+      info("  grekt deprecate @author/name@1.0.0 -m 'Use v2 instead'");
+      process.exit(1);
+    }
 
     // Require project initialization
     if (!isInitialized(projectRoot)) {

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -5,8 +5,14 @@ import { error, info as showInfo, log, colors, spinner } from "#/shared/ui/ui";
 
 export const infoCommand = new Command("info")
   .description("Show information about an artifact (requires S3 credentials)")
-  .argument("<artifact>", "Artifact ID (e.g., @author/name)")
-  .action(async (artifactId: string) => {
+  .argument("[artifact]", "Artifact ID (e.g., @author/name)")
+  .action(async (artifactId: string | undefined) => {
+    if (!artifactId) {
+      error("Artifact ID required. Usage:");
+      showInfo("  grekt info @author/name");
+      process.exit(1);
+    }
+
     if (!artifactId.startsWith("@")) {
       error("Invalid artifact ID. Use: @author/name");
       process.exit(1);

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -24,11 +24,18 @@ const CLAUDE_CATEGORY_DIRS: Record<Category, string> = {
 export const removeCommand = new Command("remove")
   .alias("rm")
   .description("Remove an installed artifact")
-  .argument("<artifact>", "Artifact ID to remove (e.g., @grekt/code-reviewer)")
+  .argument("[artifact]", "Artifact ID to remove (e.g., @grekt/code-reviewer)")
   .option("-f, --force", "Skip confirmation prompt")
-  .action(async (artifactId: string, options: { force?: boolean }) => {
+  .action(async (artifactId: string | undefined, options: { force?: boolean }) => {
     await withPromptHandler(async () => {
       const projectRoot = process.cwd();
+
+      if (!artifactId) {
+        error("Artifact ID required. Usage:");
+        info("  grekt remove @scope/artifact");
+        info("  grekt rm @scope/artifact");
+        process.exit(1);
+      }
 
       if (!isInitialized(projectRoot)) {
         error("grekt is not initialized in this directory");

--- a/src/commands/undeprecate.ts
+++ b/src/commands/undeprecate.ts
@@ -32,10 +32,16 @@ interface UndeprecateOptions {
 
 export const undeprecateCommand = new Command("undeprecate")
   .description("Remove deprecation from an artifact version (API and S3 only, not supported for GitLab/GitHub)")
-  .argument("<artifact@version>", "Artifact and version to undeprecate (e.g., @author/name@1.0.0)")
+  .argument("[artifact@version]", "Artifact and version to undeprecate (e.g., @author/name@1.0.0)")
   .option("--s3", "Use S3-compatible storage (legacy mode, env vars only)")
-  .action(async (artifactVersion: string, options: UndeprecateOptions) => {
+  .action(async (artifactVersion: string | undefined, options: UndeprecateOptions) => {
     const projectRoot = process.cwd();
+
+    if (!artifactVersion) {
+      error("Artifact and version required. Usage:");
+      info("  grekt undeprecate @author/name@1.0.0");
+      process.exit(1);
+    }
 
     // Require project initialization
     if (!isInitialized(projectRoot)) {

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -23,10 +23,18 @@ function isBumpType(value: string): value is BumpType {
 
 export const versionCommand = new Command("version")
   .description("Bump artifact versions (patch, minor, major)")
-  .argument("<bump>", "Bump type: patch, minor, or major")
+  .argument("[bump]", "Bump type: patch, minor, or major")
   .argument("[path]", "Path to artifact or directory containing artifacts", ".")
   .option("--dry-run", "Show what would happen without applying changes")
-  .action(async (bump: string, targetPath: string, options: VersionCommandOptions) => {
+  .action(async (bump: string | undefined, targetPath: string, options: VersionCommandOptions) => {
+    if (!bump) {
+      error("Bump type required. Usage:");
+      info("  grekt version patch");
+      info("  grekt version minor");
+      info("  grekt version major");
+      process.exit(1);
+    }
+
     if (!isBumpType(bump)) {
       error(`Invalid bump type: ${bump}`);
       info("Use: patch, minor, or major");

--- a/src/commands/versions.ts
+++ b/src/commands/versions.ts
@@ -5,8 +5,14 @@ import { error, info, log, colors, spinner } from "#/shared/ui/ui";
 
 export const versionsCommand = new Command("versions")
   .description("List all versions of an artifact (requires S3 credentials)")
-  .argument("<artifact>", "Artifact ID (e.g., @author/name)")
-  .action(async (artifactId: string) => {
+  .argument("[artifact]", "Artifact ID (e.g., @author/name)")
+  .action(async (artifactId: string | undefined) => {
+    if (!artifactId) {
+      error("Artifact ID required. Usage:");
+      info("  grekt versions @author/name");
+      process.exit(1);
+    }
+
     if (!artifactId.startsWith("@")) {
       error("Invalid artifact ID. Use: @author/name");
       process.exit(1);


### PR DESCRIPTION
## Summary
- Replace Commander's default "missing required argument" errors with helpful usage examples
- All commands with required arguments now show practical examples when run without them
- Affected commands: add, remove, version, config registry, config token, deprecate, undeprecate, info, versions

## Test plan
- [x] Tests pass
- [ ] Run commands without arguments to verify helpful output

🤖 Generated with [Claude Code](https://claude.com/claude-code)