### PR TITLE
feat: add specific error messages for download failures

### DIFF
--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -64,9 +64,23 @@ export const addCommand = new Command("add")
     if (!downloadResult.success) {
       // Clean up temp directory
       rmSync(tempDir, { recursive: true, force: true });
-      error(`Artifact ${colors.highlight(displayName)} not found`);
+
+      if (downloadResult.error) {
+        error(`${colors.highlight(displayName)}: ${downloadResult.error}`);
+      } else {
+        error(`Artifact ${colors.highlight(displayName)} not found`);
+      }
+
       if (source.type === "registry") {
-        info("Check .grekt/config.yaml for custom registry configuration");
+        if (downloadResult.error?.includes("not found")) {
+          info("Verify the artifact name and version are correct");
+          info("For custom registries, check .grekt/config.yaml");
+        } else if (downloadResult.error?.includes("network") || downloadResult.error?.includes("reach")) {
+          info("Check your internet connection");
+          info("For custom registries, verify the URL in .grekt/config.yaml");
+        } else if (downloadResult.error?.includes("denied") || downloadResult.error?.includes("auth")) {
+          info("This artifact may be private. Run 'grekt login' first");
+        }
       } else if (source.type === "github") {
         info("Check the repository exists and you have access");
         info("For private repos, set GITHUB_TOKEN environment variable");

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -157,8 +157,12 @@ export const publishCommand = new Command("publish")
         info("Bump the version in grekt.yaml and try again");
         process.exit(1);
       }
-    } catch {
+    } catch (err) {
       checkSpin.stop();
+      // Version check failed, but we continue with publish attempt
+      // The publish step will provide a more specific error if there's an issue
+      const message = err instanceof Error ? err.message : "Unknown error";
+      info(`Could not verify version existence: ${message}`);
     }
 
     const publisherName = getPublisherTypeName(publisher);

--- a/src/registry/api-client/api-client.ts
+++ b/src/registry/api-client/api-client.ts
@@ -147,10 +147,14 @@ export class RegistryClient {
     try {
       const metadata = await this.getArtifact(artifactId);
       if (!metadata) {
-        return { success: false };
+        return { success: false, error: "Artifact not found in registry" };
       }
 
       const resolvedVersion = version || metadata.latest;
+      if (!resolvedVersion) {
+        return { success: false, error: "No versions available for this artifact" };
+      }
+
       const tarballUrl = `${REGISTRY_URL}/${artifactId}/${resolvedVersion}.tar.gz`;
       const deprecationMessage = metadata.deprecated[resolvedVersion];
 
@@ -159,7 +163,13 @@ export class RegistryClient {
       });
 
       if (!response.ok) {
-        return { success: false };
+        if (response.status === 404) {
+          return { success: false, error: `Version ${resolvedVersion} not found` };
+        }
+        if (response.status === 401 || response.status === 403) {
+          return { success: false, error: "Access denied (check authentication)" };
+        }
+        return { success: false, error: `Registry returned ${response.status}` };
       }
 
       const buffer = await response.arrayBuffer();
@@ -171,7 +181,7 @@ export class RegistryClient {
       const validation = validateTarballContents(shellAdapter, tempTarball, targetDir, 1);
       if (!validation.safe) {
         rmSync(tempTarball, { force: true });
-        return { success: false };
+        return { success: false, error: "Security: tarball failed validation" };
       }
 
       mkdirSync(targetDir, { recursive: true });
@@ -186,8 +196,12 @@ export class RegistryClient {
         resolved: tarballUrl,
         deprecationMessage,
       };
-    } catch {
-      return { success: false };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      if (message.includes("ENOTFOUND") || message.includes("ECONNREFUSED")) {
+        return { success: false, error: "Cannot reach registry (network error)" };
+      }
+      return { success: false, error: message };
     }
   }
 

--- a/src/registry/sources/sources.ts
+++ b/src/registry/sources/sources.ts
@@ -65,7 +65,7 @@ async function downloadFromGitHub(
   if (result.success) {
     return { success: true, version: ref };
   }
-  return { success: false };
+  return { success: false, error: result.error || "Failed to download from GitHub" };
 }
 
 async function downloadFromGitLab(
@@ -85,7 +85,7 @@ async function downloadFromGitLab(
   if (result.success) {
     return { success: true, version: ref };
   }
-  return { success: false };
+  return { success: false, error: result.error || "Failed to download from GitLab" };
 }
 
 /**
@@ -123,7 +123,8 @@ async function downloadFromRegistrySource(
     const client = createRegistryClient(registry);
 
     return await client.download(artifactId, version, targetDir);
-  } catch {
-    return { success: false };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return { success: false, error: message };
   }
 }


### PR DESCRIPTION
## Summary
- Replace vague "not found" errors with detailed messages explaining why artifact download failed
- Specific error cases: network errors, auth issues, version not found, security validation
- Improve publish command to surface `versionExists` check errors instead of swallowing them

## Test plan
- [x] Tests pass (177 tests)
- [ ] Test `grekt add @nonexistent/artifact` shows "Artifact not found in registry"
- [ ] Test network disconnect shows "Cannot reach registry"