### PR TITLE
fix: auto-sync when using --core flag, remove autoSync config

### DIFF
--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -14,6 +14,7 @@ import { generateArtifactIndex } from "#/artifact/index/index";
 import { assertSafeArtifactId } from "#/artifact/validation/validation";
 import { success, error, info, log, warning, newline, colors, spinner } from "#/shared/ui/ui";
 import { compareSemver, CATEGORIES, type Category } from "@grekt-labs/cli-engine";
+import { getPlugin } from "#/sync/manager/manager";
 
 
 export const addCommand = new Command("add")
@@ -238,6 +239,34 @@ export const addCommand = new Command("add")
       log(`  ${colors.dim(`${category}:`)} ${names.join(", ")}`);
     }
 
-    newline();
-    info("Run 'grekt sync' to sync with your AI tools");
+    // Auto-sync when using --core
+    if (options.core && config.targets.length > 0) {
+      newline();
+      for (const target of config.targets) {
+        const plugin = getPlugin(target, config.customTargets);
+        const spin = spinner(`Syncing ${plugin.name}...`);
+        spin.start();
+
+        const result = await plugin.sync(lockfile, projectRoot, {
+          createTarget: true,
+          force: true,
+          projectConfig: config,
+        });
+
+        spin.stop();
+
+        for (const file of result.created) {
+          success(`Created ${file}`);
+        }
+        for (const file of result.updated) {
+          info(`Updated ${file}`);
+        }
+        for (const file of result.skipped) {
+          warning(`Skipped ${file}`);
+        }
+      }
+    } else if (!options.core) {
+      newline();
+      info("Run 'grekt sync' to sync with your AI tools");
+    }
   });

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -13,7 +13,7 @@ import {
 } from "./config/registry/registry";
 import type { ProjectConfig } from "@grekt-labs/cli-engine";
 
-const VALID_KEYS: (keyof ProjectConfig)[] = ["targets", "autoSync", "registry"];
+const VALID_KEYS: (keyof ProjectConfig)[] = ["targets", "registry"];
 
 export const configCommand = new Command("config")
   .description("Manage project configuration");
@@ -109,11 +109,6 @@ tokenCommand
   .action(unsetToken);
 
 function parseValue(key: string, value: string): unknown {
-  // Boolean values
-  if (key === "autoSync") {
-    return value === "true" || value === "1";
-  }
-
   // Array values (comma-separated)
   if (key === "targets") {
     return value.split(",").map((s) => s.trim());

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -150,7 +150,6 @@ export const initCommand = new Command("init")
     saveConfig({
       ...manifestFields,
       targets,
-      autoSync: false,
       artifacts: {},
       customTargets,
     }, projectRoot);

--- a/src/config/project/project.test.ts
+++ b/src/config/project/project.test.ts
@@ -40,7 +40,6 @@ describe("project", () => {
     test("returns parsed ProjectConfig", () => {
       const configData = {
         targets: ["claude"],
-        autoSync: true,
         artifacts: {
           "@scope/artifact": "1.0.0",
         },
@@ -50,7 +49,6 @@ describe("project", () => {
       const config = getConfig(testDir);
 
       expect(config.targets).toEqual(["claude"]);
-      expect(config.autoSync).toBe(true);
       expect(config.artifacts["@scope/artifact"]).toBe("1.0.0");
     });
 
@@ -60,7 +58,6 @@ describe("project", () => {
       const config = getConfig(testDir);
 
       expect(config.targets).toEqual([]);
-      expect(config.autoSync).toBe(false);
       expect(config.artifacts).toEqual({});
     });
   });
@@ -69,7 +66,6 @@ describe("project", () => {
     test("writes valid YAML", () => {
       const config: ProjectConfig = {
         targets: ["cursor"],
-        autoSync: false,
         artifacts: { "@test/pkg": "2.0.0" },
         customTargets: {},
       };
@@ -84,12 +80,12 @@ describe("project", () => {
 
   describe("setConfigValue", () => {
     test("updates single key", () => {
-      writeFileSync(join(testDir, "grekt.yaml"), stringify({ autoSync: false }));
+      writeFileSync(join(testDir, "grekt.yaml"), stringify({ targets: [] }));
 
-      setConfigValue("autoSync", true, testDir);
+      setConfigValue("targets", ["claude"], testDir);
 
       const config = getConfig(testDir);
-      expect(config.autoSync).toBe(true);
+      expect(config.targets).toEqual(["claude"]);
     });
   });
 

--- a/src/sync/base/base.test.ts
+++ b/src/sync/base/base.test.ts
@@ -10,7 +10,6 @@ const TEST_ARTIFACT_ID = "@scope/artifact";
 // Project config with artifact in CORE mode (so it gets copied)
 const testProjectConfig: ProjectConfig = {
   targets: [],
-  autoSync: false,
   artifacts: {
     [TEST_ARTIFACT_ID]: {
       version: "1.0.0",

--- a/src/sync/plugins/claude/claude.test.ts
+++ b/src/sync/plugins/claude/claude.test.ts
@@ -10,7 +10,6 @@ const TEST_ARTIFACT_ID = "@test/artifact";
 
 const coreProjectConfig: ProjectConfig = {
   targets: [],
-  autoSync: false,
   artifacts: {
     [TEST_ARTIFACT_ID]: { version: "1.0.0", mode: "core" },
   },

--- a/src/sync/plugins/opencode/opencode.test.ts
+++ b/src/sync/plugins/opencode/opencode.test.ts
@@ -11,7 +11,6 @@ const TEST_ARTIFACT_ID = "@test/artifact";
 
 const coreProjectConfig: ProjectConfig = {
   targets: [],
-  autoSync: false,
   artifacts: {
     [TEST_ARTIFACT_ID]: { version: "1.0.0", mode: "core" },
   },


### PR DESCRIPTION
## Summary
- Remove unused `autoSync` field from config and init
- Add automatic sync execution when adding artifacts with `--core` flag
- Update all related tests

When using `grekt add artifact --core`, sync now runs automatically for all configured targets.

## Test plan
- [x] All tests pass
- [ ] Manual test: `grekt add @grekt/tools --core` should sync automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)