### PR TITLE
fix(tarball): exclude .grekt directory from artifact packaging

### DIFF
--- a/src/artifact/tarball/tarball.ts
+++ b/src/artifact/tarball/tarball.ts
@@ -59,7 +59,10 @@ export function createTarball(options: CreateTarballOptions): TarballResult {
       const tempArtifactPath = join(tempDir, artifactDirName);
 
       mkdirSync(tempDir, { recursive: true });
-      cpSync(artifactPath, tempArtifactPath, { recursive: true });
+      cpSync(artifactPath, tempArtifactPath, {
+        recursive: true,
+        filter: (src) => !src.includes("/.grekt/"),
+      });
       injectComponentsIntoManifest(tempArtifactPath, components);
 
       sourcePath = tempArtifactPath;
@@ -68,9 +71,11 @@ export function createTarball(options: CreateTarballOptions): TarballResult {
     const artifactDir = basename(sourcePath);
     const parentDir = dirname(sourcePath);
 
-    execFileSync("tar", ["-czf", outputPath, "-C", parentDir, artifactDir], {
-      stdio: "pipe",
-    });
+    execFileSync(
+      "tar",
+      ["-czf", outputPath, "--exclude=.grekt", "-C", parentDir, artifactDir],
+      { stdio: "pipe" }
+    );
 
     return {
       success: true,


### PR DESCRIPTION
## Summary

- Prevents recursive path error when artifacts contain `.grekt/tmp` directories
- Add filter to `cpSync` to exclude `/.grekt/` paths
- Add `--exclude=.grekt` flag to tar command

## Test plan

- [x] All tests pass
- [ ] Test publish with artifact containing `.grekt/tmp`