### PR TITLE
feat: add GitHub Container Registry (GHCR) support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "grekt",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.971.0",
-        "@grekt-labs/cli-engine": "^4.7.0",
+        "@grekt-labs/cli-engine": "4.8.2",
         "@inquirer/prompts": "^7.2.0",
         "@supabase/supabase-js": "^2.91.0",
         "chalk": "^5.4.1",
@@ -123,7 +123,7 @@
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
-    "@grekt-labs/cli-engine": ["@grekt-labs/cli-engine@4.7.0", "https://npm.pkg.github.com/download/@grekt-labs/cli-engine/4.7.0/c1423dc9fe219eb6d2bcfa1efbe3280f3d0f1643", { "dependencies": { "gray-matter": "^4.0.3", "semver": "^7.7.3", "yaml": "^2.6.1", "zod": "^3.24.1" } }, "sha512-Iy3EM2T53zFB9IYUaJKQFf+e+NeLb1qCEZsZEI5WadDp+iHSZxdGlcuSfbrJJudRu39jFRFiDzEFQoxCqJsedg=="],
+    "@grekt-labs/cli-engine": ["@grekt-labs/cli-engine@4.8.2", "https://npm.pkg.github.com/download/@grekt-labs/cli-engine/4.8.2/71974c031624409e4cec0d927d97cc13f86aafd9", { "dependencies": { "gray-matter": "^4.0.3", "semver": "^7.7.3", "yaml": "^2.6.1", "zod": "^3.24.1" } }, "sha512-qS5X/a7sxnZPUwc8ySSqI2LD/vKAMqX7RPISGMkR4v1J+AD4zCh9QTJNOXaH2Zr3ABT+g8hNZjalPrb6rMeviA=="],
 
     "@inquirer/ansi": ["@inquirer/ansi@1.0.2", "", {}, "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="],
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.971.0",
-    "@grekt-labs/cli-engine": "^4.7.0",
+    "@grekt-labs/cli-engine": "4.8.2",
     "@inquirer/prompts": "^7.2.0",
     "@supabase/supabase-js": "^2.91.0",
     "chalk": "^5.4.1",


### PR DESCRIPTION
## Summary

Update cli-engine to 4.8.2 which includes GitHub Container Registry support via OCI Distribution Spec.

**Features:**
- Native download via OCI client (no external dependencies)
- Publish via `oras` CLI (for enterprise users)
- Self-hosted GitHub Enterprise support

**Configuration:**
```yaml
# .grekt/config.yaml
registries:
  "@myorg":
    type: github
    project: myorg  # Required: GHCR namespace
    # host: ghcr.io  # Optional, default ghcr.io
```

## Test plan

- [x] Build passes
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)