### PR TITLE
refactor: consolidate I/O abstractions in CLI

### DIFF
--- a/src/artifact/check/check.ts
+++ b/src/artifact/check/check.ts
@@ -1,5 +1,4 @@
-import { existsSync } from "fs";
-import { getLockfile, verifyIntegrity, getDirectorySize } from "#/context";
+import { getLockfile, verifyIntegrity, getDirectorySize, fs } from "#/context";
 import { ARTIFACTS_DIR } from "#/config/paths/paths";
 import { formatBytes, estimateTokens } from "@grekt-labs/cli-engine";
 import { success, warning, log, newline, colors, symbols } from "#/shared/ui/ui";
@@ -44,7 +43,7 @@ export function runCheck(projectRoot: string): CheckSummary {
       issues: [],
     };
 
-    if (!existsSync(artifactDir)) {
+    if (!fs.exists(artifactDir)) {
       result.status = "missing";
       result.issues.push("Directory not found");
       results.push(result);

--- a/src/artifact/component-manager/component-manager.ts
+++ b/src/artifact/component-manager/component-manager.ts
@@ -1,5 +1,5 @@
-import { existsSync, unlinkSync, readdirSync, rmSync } from "fs";
 import { join } from "path";
+import { fs } from "#/context";
 import type { ArtifactInfo } from "#/context";
 import type { ComponentSelection } from "#/artifact/selector/selector";
 import { CATEGORIES } from "@grekt-labs/cli-engine";
@@ -17,8 +17,8 @@ export function removeUnselectedFiles(
     for (const file of artifactInfo[category]) {
       if (!selection[category].includes(file.path)) {
         const filePath = join(artifactDir, file.path);
-        if (existsSync(filePath)) {
-          unlinkSync(filePath);
+        if (fs.exists(filePath)) {
+          fs.unlink(filePath);
         }
       }
     }
@@ -34,21 +34,26 @@ export function removeUnselectedFiles(
  */
 export function cleanEmptyDirs(dir: string): void {
   try {
-    const entries = readdirSync(dir, { withFileTypes: true });
+    const entries = fs.readdir(dir);
 
     for (const entry of entries) {
-      if (entry.isDirectory()) {
-        const subdir = join(dir, entry.name);
-        cleanEmptyDirs(subdir);
+      const subdir = join(dir, entry);
+      try {
+        const stat = fs.stat(subdir);
+        if (stat.isDirectory) {
+          cleanEmptyDirs(subdir);
 
-        try {
-          const remaining = readdirSync(subdir);
-          if (remaining.length === 0) {
-            rmSync(subdir, { recursive: true });
+          try {
+            const remaining = fs.readdir(subdir);
+            if (remaining.length === 0) {
+              fs.rmdir(subdir, { recursive: true });
+            }
+          } catch {
+            // Directory may have been removed or is inaccessible, skip it
           }
-        } catch {
-          // Directory may have been removed or is inaccessible, skip it
         }
+      } catch {
+        // Entry may have been removed or is inaccessible, skip it
       }
     }
   } catch {

--- a/src/artifact/index/index.ts
+++ b/src/artifact/index/index.ts
@@ -1,7 +1,6 @@
-import { existsSync, writeFileSync } from "fs";
 import { join } from "path";
 import { ARTIFACTS_DIR, INDEX_FILE } from "#/config/paths/paths";
-import { fs as cliFs, getLockfile } from "#/context";
+import { fs, getLockfile } from "#/context";
 import {
   scanArtifact,
   generateIndex,
@@ -51,24 +50,24 @@ export function generateArtifactIndex(projectRoot: string, config: ProjectConfig
   const inputs: IndexGeneratorInput[] = [];
 
   // Only scan if artifacts directory exists
-  if (existsSync(artifactsDir)) {
+  if (fs.exists(artifactsDir)) {
     // Get all artifact directories (scoped: @scope/name)
-    const scopes = cliFs.readdir(artifactsDir);
+    const scopes = fs.readdir(artifactsDir);
     for (const scope of scopes) {
       if (!scope.startsWith("@")) continue;
 
       const scopeDir = join(artifactsDir, scope);
-      const stat = cliFs.stat(scopeDir);
+      const stat = fs.stat(scopeDir);
       if (!stat.isDirectory) continue;
 
-      const names = cliFs.readdir(scopeDir);
+      const names = fs.readdir(scopeDir);
       for (const name of names) {
         const artifactDir = join(scopeDir, name);
-        const artifactStat = cliFs.stat(artifactDir);
+        const artifactStat = fs.stat(artifactDir);
         if (!artifactStat.isDirectory) continue;
 
         const artifactId = `${scope}/${name}`;
-        const scanned = scanArtifact(cliFs, artifactDir);
+        const scanned = scanArtifact(fs, artifactDir);
 
         if (!scanned) continue;
 
@@ -97,7 +96,7 @@ export function generateArtifactIndex(projectRoot: string, config: ProjectConfig
   const serialized = serializeIndex(index, { includeTerminology: true });
   const indexPath = join(projectRoot, INDEX_FILE);
 
-  writeFileSync(indexPath, serialized, "utf-8");
+  fs.writeFile(indexPath, serialized);
 }
 
 /**
@@ -109,5 +108,5 @@ export function createEmptyIndex(projectRoot: string): void {
   const serialized = serializeIndex(index, { includeTerminology: true });
   const indexPath = join(projectRoot, INDEX_FILE);
 
-  writeFileSync(indexPath, serialized, "utf-8");
+  fs.writeFile(indexPath, serialized);
 }

--- a/src/artifact/tarball/tarball.ts
+++ b/src/artifact/tarball/tarball.ts
@@ -1,8 +1,7 @@
-import { execFileSync } from "child_process";
-import { existsSync, mkdirSync, cpSync, rmSync, readFileSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { basename, dirname, join } from "path";
 import { parse, stringify } from "yaml";
+import { fs, shell } from "#/context";
 import type { Components } from "@grekt-labs/cli-engine";
 
 const TARBALL_DIR = ".grekt/tmp";
@@ -23,8 +22,8 @@ export interface CreateTarballOptions {
 
 function ensureTarballDir(projectRoot: string): string {
   const tarballDir = join(projectRoot, TARBALL_DIR);
-  if (!existsSync(tarballDir)) {
-    mkdirSync(tarballDir, { recursive: true });
+  if (!fs.exists(tarballDir)) {
+    fs.mkdir(tarballDir, { recursive: true });
   }
   return tarballDir;
 }
@@ -34,12 +33,12 @@ function injectComponentsIntoManifest(
   components: Components
 ): void {
   const manifestPath = join(artifactPath, "grekt.yaml");
-  const content = readFileSync(manifestPath, "utf-8");
+  const content = fs.readFile(manifestPath);
   const manifest = parse(content);
 
   manifest.components = components;
 
-  writeFileSync(manifestPath, stringify(manifest));
+  fs.writeFile(manifestPath, stringify(manifest));
 }
 
 export function createTarball(options: CreateTarballOptions): TarballResult {
@@ -59,8 +58,8 @@ export function createTarball(options: CreateTarballOptions): TarballResult {
       tempDir = join(tmpdir(), `grekt-tmp-${Date.now()}`);
       const tempArtifactPath = join(tempDir, artifactDirName);
 
-      mkdirSync(tempDir, { recursive: true });
-      cpSync(artifactPath, tempArtifactPath, {
+      fs.mkdir(tempDir, { recursive: true });
+      fs.copy(artifactPath, tempArtifactPath, {
         recursive: true,
         filter: (src) => !src.includes("/.grekt/"),
       });
@@ -72,11 +71,7 @@ export function createTarball(options: CreateTarballOptions): TarballResult {
     const artifactDir = basename(sourcePath);
     const parentDir = dirname(sourcePath);
 
-    execFileSync(
-      "tar",
-      ["-czf", outputPath, "--exclude=.grekt", "-C", parentDir, artifactDir],
-      { stdio: "pipe" }
-    );
+    shell.execFile("tar", ["-czf", outputPath, "--exclude=.grekt", "-C", parentDir, artifactDir]);
 
     return {
       success: true,
@@ -90,16 +85,16 @@ export function createTarball(options: CreateTarballOptions): TarballResult {
     };
   } finally {
     // Clean up temp directory
-    if (tempDir && existsSync(tempDir)) {
-      rmSync(tempDir, { recursive: true, force: true });
+    if (tempDir && fs.exists(tempDir)) {
+      fs.rmdir(tempDir, { recursive: true });
     }
   }
 }
 
 export function removeTarball(tarballPath: string): void {
   try {
-    if (existsSync(tarballPath)) {
-      rmSync(tarballPath);
+    if (fs.exists(tarballPath)) {
+      fs.unlink(tarballPath);
     }
   } catch {
     // Ignore cleanup errors

--- a/src/artifact/validation/validation.ts
+++ b/src/artifact/validation/validation.ts
@@ -1,8 +1,7 @@
-import { existsSync, readFileSync } from "fs";
 import { join, resolve } from "path";
 import { parse } from "yaml";
 import { isInitialized } from "#/config/project/project";
-import { fs as cliFs } from "#/context";
+import { fs } from "#/context";
 import { scanArtifact, ArtifactManifestSchema, isValidSemver, CATEGORIES } from "@grekt-labs/cli-engine";
 import type { InvalidFile } from "@grekt-labs/cli-engine";
 import type {
@@ -89,7 +88,7 @@ export function validateArtifact(
     };
   }
 
-  if (!existsSync(fullPath)) {
+  if (!fs.exists(fullPath)) {
     return {
       success: false,
       error: {
@@ -100,7 +99,7 @@ export function validateArtifact(
   }
 
   const manifestPath = join(fullPath, "grekt.yaml");
-  if (!existsSync(manifestPath)) {
+  if (!fs.exists(manifestPath)) {
     return {
       success: false,
       error: {
@@ -110,7 +109,7 @@ export function validateArtifact(
     };
   }
 
-  const rawManifest = parse(readFileSync(manifestPath, "utf-8"));
+  const rawManifest = parse(fs.readFile(manifestPath));
   const manifestResult = ArtifactManifestSchema.safeParse(rawManifest);
 
   if (!manifestResult.success) {
@@ -166,7 +165,7 @@ export function validateArtifact(
     }
   }
 
-  const scanned = scanArtifact(cliFs, fullPath);
+  const scanned = scanArtifact(fs, fullPath);
   if (!scanned) {
     return {
       success: false,

--- a/src/auth/oauth/oauth.ts
+++ b/src/auth/oauth/oauth.ts
@@ -1,26 +1,26 @@
 import { createServer, type Server } from "http";
-import { execFileSync } from "child_process";
 import { getSupabaseClient } from "#/auth/session/session";
+import { shell } from "#/context";
 
 const LOGIN_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
 /**
  * Open a URL in the default browser.
  * Supports macOS, Windows, and Linux.
- * Uses execFileSync with array args to prevent URL injection.
+ * Uses execFile with array args to prevent URL injection.
  */
 export function openBrowser(url: string): boolean {
   const platform = process.platform;
 
   try {
     if (platform === "darwin") {
-      execFileSync("open", [url], { stdio: "ignore" });
+      shell.execFile("open", [url]);
     } else if (platform === "win32") {
       // Use rundll32 to avoid cmd shell interpretation of special chars like &
       // This directly invokes the URL protocol handler without shell parsing
-      execFileSync("rundll32", ["url.dll,FileProtocolHandler", url], { stdio: "ignore" });
+      shell.execFile("rundll32", ["url.dll,FileProtocolHandler", url]);
     } else {
-      execFileSync("xdg-open", [url], { stdio: "ignore" });
+      shell.execFile("xdg-open", [url]);
     }
     return true;
   } catch {

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,7 +1,6 @@
 import { Command } from "commander";
-import { randomUUID } from "crypto";
-import { existsSync, mkdirSync, rmSync, renameSync } from "fs";
 import { isInitialized, getConfig, saveConfig } from "#/config/project/project";
+import { fs, cryptoProvider } from "#/context";
 import { getLockfile, saveLockfile } from "#/context";
 import { ARTIFACTS_DIR } from "#/config/paths/paths";
 import { parseSource, downloadFromSource } from "#/registry/sources/sources";
@@ -44,13 +43,13 @@ export const addCommand = new Command("add")
     const displayName = getSourceDisplayName(source);
 
     // For git sources, use temp dir first, then rename after we know the artifact ID
-    const tempDir = `${projectRoot}/${ARTIFACTS_DIR}/.tmp-${randomUUID()}`;
+    const tempDir = `${projectRoot}/${ARTIFACTS_DIR}/.tmp-${cryptoProvider.randomUUID()}`;
 
     const spin = spinner(`Downloading ${displayName}...`);
     spin.start();
 
     // Download artifact from source
-    mkdirSync(tempDir, { recursive: true });
+    fs.mkdir(tempDir, { recursive: true });
     const downloadResult = await downloadFromSource(source, tempDir, projectRoot);
 
     spin.stop();
@@ -63,7 +62,7 @@ export const addCommand = new Command("add")
 
     if (!downloadResult.success) {
       // Clean up temp directory
-      rmSync(tempDir, { recursive: true, force: true });
+      fs.rmdir(tempDir, { recursive: true });
 
       if (downloadResult.error) {
         error(`${colors.highlight(displayName)}: ${downloadResult.error}`);
@@ -95,7 +94,7 @@ export const addCommand = new Command("add")
     const artifactInfo = scanArtifact(tempDir);
 
     if (!artifactInfo) {
-      rmSync(tempDir, { recursive: true, force: true });
+      fs.rmdir(tempDir, { recursive: true });
       error("Invalid artifact: missing grekt.yaml or invalid structure");
       process.exit(1);
     }
@@ -106,7 +105,7 @@ export const addCommand = new Command("add")
     try {
       assertSafeArtifactId(resolvedArtifactId);
     } catch {
-      rmSync(tempDir, { recursive: true, force: true });
+      fs.rmdir(tempDir, { recursive: true });
       error("Invalid artifact: manifest contains unsafe characters in author or name");
       process.exit(1);
     }
@@ -116,7 +115,7 @@ export const addCommand = new Command("add")
 
     // Check if already installed - update if newer version, skip if same/older
     const lockfile = getLockfile(projectRoot);
-    if (existsSync(targetDir)) {
+    if (fs.exists(targetDir)) {
       const existing = lockfile.artifacts[resolvedArtifactId];
       const newVersion = artifactInfo.manifest.version;
 
@@ -124,7 +123,7 @@ export const addCommand = new Command("add")
         try {
           const comparison = compareSemver(newVersion, existing.version);
           if (comparison <= 0) {
-            rmSync(tempDir, { recursive: true, force: true });
+            fs.rmdir(tempDir, { recursive: true });
             info(`Already installed: ${colors.highlight(resolvedArtifactId)}@${existing.version}`);
             if (comparison < 0) {
               info(`Current version (${existing.version}) is newer than requested (${newVersion})`);
@@ -139,17 +138,17 @@ export const addCommand = new Command("add")
       }
 
       // Remove old version to replace with new
-      rmSync(targetDir, { recursive: true, force: true });
+      fs.rmdir(targetDir, { recursive: true });
     }
 
     // Ensure parent directory exists (for scoped artifacts like @scope/name)
     const parentDir = targetDir.substring(0, targetDir.lastIndexOf("/"));
-    if (!existsSync(parentDir)) {
-      mkdirSync(parentDir, { recursive: true });
+    if (!fs.exists(parentDir)) {
+      fs.mkdir(parentDir, { recursive: true });
     }
 
     // Move temp dir to final location
-    renameSync(tempDir, targetDir);
+    fs.rename(tempDir, targetDir);
 
     // Determine which components to install (default: all)
     let selection: ComponentSelection = createEmptySelection();
@@ -170,7 +169,7 @@ export const addCommand = new Command("add")
 
         if (isEmptySelection(selection)) {
           warning("No components selected");
-          rmSync(targetDir, { recursive: true, force: true });
+          fs.rmdir(targetDir, { recursive: true });
           process.exit(0);
         }
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
-import { existsSync, mkdirSync } from "fs";
 import { basename } from "path";
+import { fs } from "#/context";
 import { input, confirm } from "@inquirer/prompts";
 import { isInitialized, saveConfig } from "#/config/project/project";
 import { getPluginChoices, getDefaultTarget } from "#/sync/manager/manager";
@@ -116,8 +116,8 @@ export const initCommand = new Command("init")
 
     // Create .grekt/artifacts/ directory
     const artifactsPath = `${projectRoot}/${ARTIFACTS_DIR}`;
-    if (!existsSync(artifactsPath)) {
-      mkdirSync(artifactsPath, { recursive: true });
+    if (!fs.exists(artifactsPath)) {
+      fs.mkdir(artifactsPath, { recursive: true });
     }
 
     // Create grekt.yaml

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,7 +1,6 @@
 import { Command } from "commander";
-import { existsSync, mkdirSync, rmSync } from "fs";
 import { isInitialized, getConfig, getLocalConfig } from "#/config/project/project";
-import { getLockfile, lockfileExists } from "#/context";
+import { getLockfile, lockfileExists, fs } from "#/context";
 import { ARTIFACTS_DIR } from "#/config/paths/paths";
 import { parseSource, downloadFromSource, getSourceToken } from "#/registry/sources/sources";
 import { downloadAndExtractTarball } from "#/registry/download/download";
@@ -10,7 +9,6 @@ import { generateArtifactIndex } from "#/artifact/index/index";
 import { isSafeArtifactId } from "#/artifact/validation/validation";
 import { resolveRegistry } from "#/registry/factory/factory";
 import { parseArtifactId, getGitLabHeaders, getGitHubHeaders, scanArtifact } from "@grekt-labs/cli-engine";
-import { fs as cliFs } from "#/context";
 import { success, error, info, warning, log, newline, colors, spinner } from "#/shared/ui/ui";
 
 /**
@@ -92,7 +90,7 @@ export const installCommand = new Command("install")
       const targetDir = `${projectRoot}/${ARTIFACTS_DIR}/${artifactId}`;
 
       // Check if already installed
-      if (existsSync(targetDir) && !options.force) {
+      if (fs.exists(targetDir) && !options.force) {
         // Verify existing installation
         const integrity = verifyIntegrity(targetDir, entry.files);
 
@@ -103,10 +101,10 @@ export const installCommand = new Command("install")
         } else {
           // Existing but corrupted, will reinstall
           warning(`${artifactId} has integrity issues, reinstalling...`);
-          rmSync(targetDir, { recursive: true, force: true });
+          fs.rmdir(targetDir, { recursive: true });
         }
-      } else if (existsSync(targetDir) && options.force) {
-        rmSync(targetDir, { recursive: true, force: true });
+      } else if (fs.exists(targetDir) && options.force) {
+        fs.rmdir(targetDir, { recursive: true });
       }
 
       const spin = spinner(`Installing ${artifactId}@${entry.version}...`);
@@ -124,7 +122,7 @@ export const installCommand = new Command("install")
         // Fallback for old lockfiles without resolved
         const sourceStr = entry.source || artifactId;
         const source = parseSource(sourceStr);
-        mkdirSync(targetDir, { recursive: true });
+        fs.mkdir(targetDir, { recursive: true });
         const downloadResult = await downloadFromSource(source, targetDir, projectRoot);
         downloadSuccess = downloadResult.success;
 
@@ -138,7 +136,7 @@ export const installCommand = new Command("install")
 
       if (!downloadSuccess) {
         spin.stop();
-        rmSync(targetDir, { recursive: true, force: true });
+        fs.rmdir(targetDir, { recursive: true });
         error(`Failed to download ${artifactId}`);
         failed++;
         continue;
@@ -151,10 +149,10 @@ export const installCommand = new Command("install")
         spin.stop();
 
         // Scan for frontmatter errors before deleting
-        const scanned = scanArtifact(cliFs, targetDir);
+        const scanned = scanArtifact(fs, targetDir);
         const hasValidationErrors = scanned && scanned.invalidFiles.length > 0;
 
-        rmSync(targetDir, { recursive: true, force: true });
+        fs.rmdir(targetDir, { recursive: true });
         error(`Integrity check failed for ${artifactId}`);
 
         // Show frontmatter validation errors if any

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,7 +1,6 @@
 import { Command } from "commander";
-import { existsSync } from "fs";
 import { isInitialized } from "#/config/project/project";
-import { getLockfile, getDirectorySize } from "#/context";
+import { getLockfile, getDirectorySize, fs } from "#/context";
 import { ARTIFACTS_DIR } from "#/config/paths/paths";
 import { formatBytes, estimateTokens } from "@grekt-labs/cli-engine";
 import { error, info, log, colors, newline } from "#/shared/ui/ui";
@@ -44,7 +43,7 @@ export const listCommand = new Command("list")
       let size = 0;
       let sizeStr = "";
 
-      if (existsSync(artifactDir)) {
+      if (fs.exists(artifactDir)) {
         size = getDirectorySize(artifactDir);
         totalSize += size;
         sizeStr = formatBytes(size);

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
-import { existsSync, rmSync, readdirSync, unlinkSync } from "fs";
 import { join } from "path";
+import { fs } from "#/context";
 import { confirm } from "@inquirer/prompts";
 import { isInitialized, getConfig, saveConfig } from "#/config/project/project";
 import { getLockfile, saveLockfile } from "#/context";
@@ -93,14 +93,14 @@ export const removeCommand = new Command("remove")
     const removed: string[] = [];
 
     // Remove from .grekt/artifacts/
-    if (existsSync(artifactDir)) {
-      rmSync(artifactDir, { recursive: true, force: true });
+    if (fs.exists(artifactDir)) {
+      fs.rmdir(artifactDir, { recursive: true });
       removed.push(`${ARTIFACTS_DIR}/${artifactId}`);
     }
 
     // Remove synced files from .claude/
     const claudeDir = `${projectRoot}/${CLAUDE_DIR}`;
-    if (existsSync(claudeDir)) {
+    if (fs.exists(claudeDir)) {
       for (const category of CATEGORIES) {
         const categoryDir = CLAUDE_CATEGORY_DIRS[category];
         const paths = artifact[category];
@@ -111,8 +111,8 @@ export const removeCommand = new Command("remove")
           const targetName = getSafeFilename(artifactId, filePath);
 
           const targetPath = `${projectRoot}/${categoryDir}/${targetName}`;
-          if (existsSync(targetPath)) {
-            unlinkSync(targetPath);
+          if (fs.exists(targetPath)) {
+            fs.unlink(targetPath);
             removed.push(`${categoryDir}/${targetName}`);
           }
         }
@@ -149,10 +149,10 @@ export const removeCommand = new Command("remove")
  * Remove directory if empty
  */
 function cleanEmptyDir(dir: string): void {
-  if (existsSync(dir)) {
-    const files = readdirSync(dir);
+  if (fs.exists(dir)) {
+    const files = fs.readdir(dir);
     if (files.length === 0) {
-      rmSync(dir, { recursive: true });
+      fs.rmdir(dir, { recursive: true });
     }
   }
 }

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
-import { existsSync, readdirSync, readFileSync, writeFileSync } from "fs";
 import { join, resolve } from "path";
+import { fs } from "#/context";
 import { parse as parseYaml } from "yaml";
 import {
   ArtifactManifestSchema,
@@ -43,7 +43,7 @@ export const versionCommand = new Command("version")
 
     const absolutePath = resolve(targetPath);
 
-    if (!existsSync(absolutePath)) {
+    if (!fs.exists(absolutePath)) {
       error(`Path not found: ${absolutePath}`);
       process.exit(1);
     }
@@ -68,7 +68,7 @@ export const versionCommand = new Command("version")
 
     for (const artifactPath of artifactPaths) {
       const manifestPath = join(artifactPath, MANIFEST_FILE);
-      const manifestContent = readFileSync(manifestPath, "utf-8");
+      const manifestContent = fs.readFile(manifestPath);
       const parsed = parseYaml(manifestContent);
       const manifest = ArtifactManifestSchema.parse(parsed);
       const artifactId = getArtifactIdFromManifest(manifest);
@@ -82,7 +82,7 @@ export const versionCommand = new Command("version")
           /^version:\s*["']?[\d.]+[-\w.]*["']?/m,
           `version: "${newVersion}"`
         );
-        writeFileSync(manifestPath, updatedContent);
+        fs.writeFile(manifestPath, updatedContent);
         updated++;
       }
     }
@@ -103,20 +103,20 @@ function findArtifacts(basePath: string): string[] {
   const artifacts: string[] = [];
 
   // Check if basePath itself is an artifact
-  if (existsSync(join(basePath, MANIFEST_FILE))) {
+  if (fs.exists(join(basePath, MANIFEST_FILE))) {
     artifacts.push(basePath);
     return artifacts;
   }
 
   // Scan subdirectories
   try {
-    const entries = readdirSync(basePath, { withFileTypes: true });
+    const entries = fs.readdir(basePath);
     for (const entry of entries) {
-      if (entry.isDirectory() && !entry.name.startsWith(".")) {
-        const subPath = join(basePath, entry.name);
-        if (existsSync(join(subPath, MANIFEST_FILE))) {
-          artifacts.push(subPath);
-        }
+      if (entry.startsWith(".")) continue;
+      const subPath = join(basePath, entry);
+      const stat = fs.stat(subPath);
+      if (stat.isDirectory && fs.exists(join(subPath, MANIFEST_FILE))) {
+        artifacts.push(subPath);
       }
     }
   } catch {

--- a/src/config/project/project.ts
+++ b/src/config/project/project.ts
@@ -1,6 +1,6 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from "fs";
 import { dirname, resolve } from "path";
 import { parse, stringify } from "yaml";
+import { fs } from "#/context";
 import {
   ProjectConfigSchema,
   LocalConfigSchema,
@@ -18,16 +18,16 @@ const LOCAL_CONFIG_FILE = "config.yaml";
 
 function ensureDir(filepath: string): void {
   const dir = dirname(filepath);
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
+  if (!fs.exists(dir)) {
+    fs.mkdir(dir, { recursive: true });
   }
 }
 
 function readYaml<T>(filepath: string, defaultValue: T): T {
-  if (!existsSync(filepath)) {
+  if (!fs.exists(filepath)) {
     return defaultValue;
   }
-  const content = readFileSync(filepath, "utf-8");
+  const content = fs.readFile(filepath);
   const parsed = parse(content);
   if (parsed === null || parsed === undefined) {
     return defaultValue;
@@ -38,9 +38,9 @@ function readYaml<T>(filepath: string, defaultValue: T): T {
 function writeYaml(filepath: string, data: unknown, secure = false): void {
   ensureDir(filepath);
   const content = stringify(data);
-  writeFileSync(filepath, content, "utf-8");
+  fs.writeFile(filepath, content);
   if (secure) {
-    chmodSync(filepath, 0o600);
+    fs.chmod(filepath, 0o600);
   }
 }
 
@@ -64,7 +64,7 @@ export function setConfigValue(key: keyof ProjectConfig, value: unknown, project
 
 // Check if grekt is initialized
 export function isInitialized(projectRoot: string = process.cwd()): boolean {
-  return existsSync(`${projectRoot}/${GREKT_YAML}`);
+  return fs.exists(`${projectRoot}/${GREKT_YAML}`);
 }
 
 // Walk up directory tree to find .grekt/config.yaml
@@ -73,7 +73,7 @@ function findLocalConfigPath(startDir: string): string | null {
 
   while (true) {
     const configPath = `${current}/${GREKT_DIR}/${LOCAL_CONFIG_FILE}`;
-    if (existsSync(configPath)) {
+    if (fs.exists(configPath)) {
       return configPath;
     }
 
@@ -153,8 +153,8 @@ function writeLocalConfigWithComments(filepath: string, config: LocalConfig): vo
   }
 
   const content = lines.length > 0 ? lines.join("\n") : "{}\n";
-  writeFileSync(filepath, content, "utf-8");
-  chmodSync(filepath, 0o600);
+  fs.writeFile(filepath, content);
+  fs.chmod(filepath, 0o600);
 }
 
 // Session management

--- a/src/context/crypto.ts
+++ b/src/context/crypto.ts
@@ -1,0 +1,23 @@
+import { randomUUID } from "node:crypto";
+
+/**
+ * Interface for cryptographic operations.
+ * Provides a testable abstraction over Node.js crypto module.
+ */
+export interface CryptoProvider {
+  randomUUID(): string;
+}
+
+/**
+ * Real CryptoProvider implementation using Node.js crypto.
+ */
+export function createCryptoProvider(): CryptoProvider {
+  return {
+    randomUUID,
+  };
+}
+
+/**
+ * Singleton instance for convenience.
+ */
+export const cryptoProvider = createCryptoProvider();

--- a/src/context/filesystem.ts
+++ b/src/context/filesystem.ts
@@ -9,14 +9,33 @@ import {
   rmSync,
   copyFileSync,
   renameSync,
+  chmodSync,
+  cpSync,
 } from "fs";
 import type { FileSystem } from "@grekt-labs/cli-engine";
+
+/**
+ * Copy options for recursive directory copying.
+ */
+export interface CopyOptions {
+  recursive?: boolean;
+  filter?: (src: string) => boolean;
+}
+
+/**
+ * Extended FileSystem interface with additional CLI-specific methods.
+ * Extends cli-engine's FileSystem with chmod and copy operations.
+ */
+export interface ExtendedFileSystem extends FileSystem {
+  chmod(path: string, mode: number): void;
+  copy(src: string, dest: string, options?: CopyOptions): void;
+}
 
 /**
  * Real FileSystem implementation using Node.js fs module.
  * This is passed to cli-engine functions for actual file operations.
  */
-export function createFileSystem(): FileSystem {
+export function createFileSystem(): ExtendedFileSystem {
   return {
     readFile: (path: string) => readFileSync(path, "utf-8"),
     readFileBinary: (path: string) => readFileSync(path),
@@ -41,6 +60,10 @@ export function createFileSystem(): FileSystem {
     },
     copyFile: (src: string, dest: string) => copyFileSync(src, dest),
     rename: (src: string, dest: string) => renameSync(src, dest),
+    chmod: (path: string, mode: number) => chmodSync(path, mode),
+    copy: (src: string, dest: string, options?: CopyOptions) => {
+      cpSync(src, dest, options);
+    },
   };
 }
 

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,4 +1,5 @@
-export { createFileSystem, fs } from "./filesystem";
+export { createCryptoProvider, cryptoProvider, type CryptoProvider } from "./crypto";
+export { createFileSystem, fs, type ExtendedFileSystem, type CopyOptions } from "./filesystem";
 export { createHttpClient, http } from "./http";
 export { createShellExecutor, shell } from "./shell";
 export { createTokenProvider } from "./tokens";

--- a/src/registry/api-client/api-client.ts
+++ b/src/registry/api-client/api-client.ts
@@ -1,19 +1,8 @@
-import { mkdirSync, writeFileSync, rmSync } from "fs";
-import { execFileSync } from "child_process";
-import { randomUUID } from "crypto";
-import type { ArtifactMetadata, ShellExecutor } from "@grekt-labs/cli-engine";
+import type { ArtifactMetadata } from "@grekt-labs/cli-engine";
 import { sortVersionsDesc, getHighestVersion, validateTarballContents } from "@grekt-labs/cli-engine";
 import { getSupabaseClient, getSession, getSupabaseUrl } from "#/auth/session/session";
+import { fs, shell, http, cryptoProvider } from "#/context";
 import { REGISTRY_URL } from "#/constants";
-
-/**
- * Minimal ShellExecutor adapter for validateTarballContents.
- */
-const shellAdapter: ShellExecutor = {
-  execFile: (command: string, args: string[]) => {
-    return execFileSync(command, args, { stdio: "pipe" }).toString();
-  },
-};
 
 
 
@@ -25,6 +14,7 @@ export interface VersionInfo {
 
 export interface DownloadResult {
   success: boolean;
+  error?: string;
   version?: string;
   resolved?: string;
   deprecationMessage?: string;
@@ -158,7 +148,7 @@ export class RegistryClient {
       const tarballUrl = `${REGISTRY_URL}/${artifactId}/${resolvedVersion}.tar.gz`;
       const deprecationMessage = metadata.deprecated[resolvedVersion];
 
-      const response = await fetch(tarballUrl, {
+      const response = await http.fetch(tarballUrl, {
         headers: { "User-Agent": "grekt-cli" },
       });
 
@@ -173,22 +163,20 @@ export class RegistryClient {
       }
 
       const buffer = await response.arrayBuffer();
-      const tempTarball = `/tmp/grekt-${randomUUID()}.tar.gz`;
-      writeFileSync(tempTarball, Buffer.from(buffer));
+      const tempTarball = `/tmp/grekt-${cryptoProvider.randomUUID()}.tar.gz`;
+      fs.writeFileBinary(tempTarball, Buffer.from(buffer));
 
       // Validate tarball contents BEFORE extraction (prevents path traversal)
       // stripComponents=1 matches the extraction below
-      const validation = validateTarballContents(shellAdapter, tempTarball, targetDir, 1);
+      const validation = validateTarballContents(shell, tempTarball, targetDir, 1);
       if (!validation.safe) {
-        rmSync(tempTarball, { force: true });
+        fs.unlink(tempTarball);
         return { success: false, error: "Security: tarball failed validation" };
       }
 
-      mkdirSync(targetDir, { recursive: true });
-      execFileSync("tar", ["-xzf", tempTarball, "-C", targetDir, "--strip-components=1"], {
-        stdio: "pipe",
-      });
-      rmSync(tempTarball, { force: true });
+      fs.mkdir(targetDir, { recursive: true });
+      shell.execFile("tar", ["-xzf", tempTarball, "-C", targetDir, "--strip-components=1"]);
+      fs.unlink(tempTarball);
 
       return {
         success: true,
@@ -254,7 +242,7 @@ export class RegistryClient {
       throw new Error("Not authenticated");
     }
 
-    const response = await fetch(`${this.edgeFunctionUrl}/publish`, {
+    const response = await http.fetch(`${this.edgeFunctionUrl}/publish`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/src/registry/download/download.ts
+++ b/src/registry/download/download.ts
@@ -1,8 +1,6 @@
-import { mkdirSync, writeFileSync, existsSync, rmSync } from "fs";
-import { execFileSync } from "child_process";
-import { randomUUID } from "crypto";
 import { tmpdir } from "os";
 import { join } from "path";
+import { fs, shell, http, cryptoProvider } from "#/context";
 
 interface DownloadOptions {
   headers?: Record<string, string>;
@@ -35,10 +33,10 @@ export async function downloadAndExtractTarball(
     ...headers,
   };
 
-  const tempTarball = join(tmpdir(), `grekt-${randomUUID()}.tar.gz`);
+  const tempTarball = join(tmpdir(), `grekt-${cryptoProvider.randomUUID()}.tar.gz`);
 
   try {
-    const response = await fetch(url, {
+    const response = await http.fetch(url, {
       headers: finalHeaders,
       redirect: "follow",
     });
@@ -51,19 +49,17 @@ export async function downloadAndExtractTarball(
     }
 
     const buffer = await response.arrayBuffer();
-    writeFileSync(tempTarball, Buffer.from(buffer));
+    fs.writeFileBinary(tempTarball, Buffer.from(buffer));
 
     // Ensure target directory exists
-    mkdirSync(targetDir, { recursive: true });
+    fs.mkdir(targetDir, { recursive: true });
 
     // Extract tarball
     const tarArgs = ["-xzf", tempTarball, "-C", targetDir];
     if (stripComponents > 0) {
       tarArgs.push(`--strip-components=${stripComponents}`);
     }
-    execFileSync("tar", tarArgs, {
-      stdio: "pipe",
-    });
+    shell.execFile("tar", tarArgs);
 
     return { success: true };
   } catch (err) {
@@ -73,8 +69,8 @@ export async function downloadAndExtractTarball(
     };
   } finally {
     // Always clean up temp file
-    if (existsSync(tempTarball)) {
-      rmSync(tempTarball, { force: true });
+    if (fs.exists(tempTarball)) {
+      fs.unlink(tempTarball);
     }
   }
 }

--- a/src/registry/publishers/api-publisher.ts
+++ b/src/registry/publishers/api-publisher.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from "fs";
 import { isAuthenticated, isSupabaseConfigured } from "#/auth/session/session";
+import { fs, http } from "#/context";
 import { createRegistryClient } from "#/registry/api-client/api-client";
 import type { Publisher, PublishContext, PublishResult } from "./publisher.types";
 
@@ -39,10 +39,10 @@ export class ApiPublisher implements Publisher {
       const { uploadUrl } = await client.publish(ctx.artifactId, ctx.version);
 
       // Upload tarball to signed URL
-      const body = readFileSync(ctx.tarballPath);
-      const uploadResponse = await fetch(uploadUrl, {
+      const fileBuffer = fs.readFileBinary(ctx.tarballPath);
+      const uploadResponse = await http.fetch(uploadUrl, {
         method: "PUT",
-        body,
+        body: new Uint8Array(fileBuffer),
         headers: { "Content-Type": "application/gzip" },
       });
 

--- a/src/registry/publishers/s3-publisher.ts
+++ b/src/registry/publishers/s3-publisher.ts
@@ -1,6 +1,6 @@
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
-import { readFileSync } from "fs";
 import type { S3Credentials } from "@grekt-labs/cli-engine";
+import { fs } from "#/context";
 import {
   getArtifactMetadata,
   saveArtifactMetadata,
@@ -109,7 +109,7 @@ export class S3Publisher implements Publisher {
     });
 
     const key = `artifacts/${ctx.artifactId}/${ctx.version}.tar.gz`;
-    const body = readFileSync(ctx.tarballPath);
+    const body = fs.readFileBinary(ctx.tarballPath);
 
     try {
       await client.send(

--- a/src/sync/base/base.ts
+++ b/src/sync/base/base.ts
@@ -1,4 +1,3 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync } from "fs";
 import { dirname, join } from "path";
 import type { SyncPlugin, SyncResult, SyncOptions, SyncPreview, FolderPluginConfig, RulesOnlyPluginConfig } from "#/sync/sync.types";
 import {
@@ -12,7 +11,7 @@ import {
 } from "@grekt-labs/cli-engine";
 import { ARTIFACTS_DIR } from "#/config/paths/paths";
 import { getSafeFilename, generateDefaultBlockContent, GREKT_SECTION_HEADER } from "@grekt-labs/cli-engine";
-import { fs as cliFs } from "#/context";
+import { fs } from "#/context";
 
 // MD categories can be synced to folder targets
 const SYNCABLE_CATEGORIES = getCategoriesForFormat("md");
@@ -23,8 +22,8 @@ export { generateDefaultBlockContent } from "@grekt-labs/cli-engine";
 // Utility functions
 export function ensureDir(filepath: string): void {
   const dir = dirname(filepath);
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
+  if (!fs.exists(dir)) {
+    fs.mkdir(dir, { recursive: true });
   }
 }
 
@@ -75,14 +74,14 @@ export function createFolderPlugin(config: FolderPluginConfig): SyncPlugin {
     const filepath = `${projectRoot}/${contextEntryPoint}`;
     const managedBlock = generateRulesContent(lockfile);
 
-    if (!existsSync(filepath)) {
+    if (!fs.exists(filepath)) {
       ensureDir(filepath);
-      writeFileSync(filepath, managedBlock + "\n", "utf-8");
+      fs.writeFile(filepath, managedBlock + "\n");
       result.created.push(contextEntryPoint);
       return;
     }
 
-    const content = readFileSync(filepath, "utf-8");
+    const content = fs.readFile(filepath);
 
     // If section header already exists, nothing to do
     if (content.includes(GREKT_SECTION_HEADER)) {
@@ -90,7 +89,7 @@ export function createFolderPlugin(config: FolderPluginConfig): SyncPlugin {
     }
 
     // Prepend to file
-    writeFileSync(filepath, managedBlock + "\n\n" + content.trimStart(), "utf-8");
+    fs.writeFile(filepath, managedBlock + "\n\n" + content.trimStart());
     result.updated.push(contextEntryPoint);
   }
 
@@ -108,7 +107,7 @@ export function createFolderPlugin(config: FolderPluginConfig): SyncPlugin {
     targetFile: targetDir,
 
     targetExists(projectRoot: string): boolean {
-      return existsSync(`${projectRoot}/${targetDir}`);
+      return fs.exists(`${projectRoot}/${targetDir}`);
     },
 
     async sync(lockfile: Lockfile, projectRoot: string, options: SyncOptions): Promise<SyncResult> {
@@ -127,8 +126,8 @@ export function createFolderPlugin(config: FolderPluginConfig): SyncPlugin {
       const dirs = [targetDir, ...SYNCABLE_CATEGORIES.map(getCategoryDir)];
       for (const dir of dirs) {
         const fullPath = `${projectRoot}/${dir}`;
-        if (!existsSync(fullPath)) {
-          mkdirSync(fullPath, { recursive: true });
+        if (!fs.exists(fullPath)) {
+          fs.mkdir(fullPath, { recursive: true });
         }
       }
 
@@ -142,7 +141,7 @@ export function createFolderPlugin(config: FolderPluginConfig): SyncPlugin {
         const artifactDir = `${projectRoot}/${ARTIFACTS_DIR}/${artifactId}`;
 
         // Scan artifact to determine file categories from frontmatter
-        const artifactInfo = scanArtifact(cliFs, artifactDir);
+        const artifactInfo = scanArtifact(fs, artifactDir);
         if (!artifactInfo) {
           result.skipped.push(`${artifactId} (invalid artifact)`);
           continue;
@@ -161,10 +160,10 @@ export function createFolderPlugin(config: FolderPluginConfig): SyncPlugin {
             const targetName = getTargetPath(artifactId, category, filePath);
             const target = `${projectRoot}/${categoryDir}/${targetName}`;
 
-            if (existsSync(source)) {
+            if (fs.exists(source)) {
               ensureDir(target);
-              const existed = existsSync(target);
-              copyFileSync(source, target);
+              const existed = fs.exists(target);
+              fs.copyFile(source, target);
               if (existed) {
                 result.updated.push(`${categoryDir}/${targetName}`);
               } else {
@@ -184,7 +183,7 @@ export function createFolderPlugin(config: FolderPluginConfig): SyncPlugin {
     preview(lockfile: Lockfile, projectRoot: string, options?: SyncOptions): SyncPreview {
       const preview: SyncPreview = { willCreate: [], willUpdate: [], willSkip: [] };
 
-      if (!existsSync(`${projectRoot}/${targetDir}`)) {
+      if (!fs.exists(`${projectRoot}/${targetDir}`)) {
         preview.willCreate.push(targetDir);
       }
 
@@ -197,7 +196,7 @@ export function createFolderPlugin(config: FolderPluginConfig): SyncPlugin {
         const artifactDir = `${projectRoot}/${ARTIFACTS_DIR}/${artifactId}`;
 
         // Scan artifact to determine file categories from frontmatter
-        const artifactInfo = scanArtifact(cliFs, artifactDir);
+        const artifactInfo = scanArtifact(fs, artifactDir);
         if (!artifactInfo) {
           preview.willSkip.push(`${artifactId} (invalid artifact)`);
           continue;
@@ -215,9 +214,9 @@ export function createFolderPlugin(config: FolderPluginConfig): SyncPlugin {
             const targetName = getTargetPath(artifactId, category, filePath);
             const target = `${projectRoot}/${categoryDir}/${targetName}`;
 
-            if (!existsSync(source)) {
+            if (!fs.exists(source)) {
               preview.willSkip.push(`${artifactId}/${filePath} (source not found)`);
-            } else if (existsSync(target)) {
+            } else if (fs.exists(target)) {
               preview.willUpdate.push(`${categoryDir}/${targetName}`);
             } else {
               preview.willCreate.push(`${categoryDir}/${targetName}`);
@@ -227,7 +226,7 @@ export function createFolderPlugin(config: FolderPluginConfig): SyncPlugin {
       }
 
       if (contextEntryPoint) {
-        if (!existsSync(`${projectRoot}/${contextEntryPoint}`)) {
+        if (!fs.exists(`${projectRoot}/${contextEntryPoint}`)) {
           preview.willCreate.push(contextEntryPoint);
         } else {
           preview.willUpdate.push(contextEntryPoint);
@@ -251,7 +250,7 @@ export function createRulesOnlyPlugin(config: RulesOnlyPluginConfig): SyncPlugin
     targetFile: contextEntryPoint,
 
     targetExists(projectRoot: string): boolean {
-      return existsSync(`${projectRoot}/${contextEntryPoint}`);
+      return fs.exists(`${projectRoot}/${contextEntryPoint}`);
     },
 
     async sync(lockfile: Lockfile, projectRoot: string, options: SyncOptions): Promise<SyncResult> {
@@ -269,17 +268,17 @@ export function createRulesOnlyPlugin(config: RulesOnlyPluginConfig): SyncPlugin
       const filepath = `${projectRoot}/${contextEntryPoint}`;
       const managedBlock = generateRulesContent(lockfile);
 
-      if (!existsSync(filepath)) {
+      if (!fs.exists(filepath)) {
         if (!options.createTarget) {
           result.skipped.push(`${contextEntryPoint} (file doesn't exist)`);
           return result;
         }
-        writeFileSync(filepath, managedBlock, "utf-8");
+        fs.writeFile(filepath, managedBlock);
         result.created.push(contextEntryPoint);
         return result;
       }
 
-      const content = readFileSync(filepath, "utf-8");
+      const content = fs.readFile(filepath);
 
       // If section header already exists, nothing to do
       if (content.includes(GREKT_SECTION_HEADER)) {
@@ -287,7 +286,7 @@ export function createRulesOnlyPlugin(config: RulesOnlyPluginConfig): SyncPlugin
       }
 
       // Prepend to file
-      writeFileSync(filepath, managedBlock + "\n\n" + content.trimStart(), "utf-8");
+      fs.writeFile(filepath, managedBlock + "\n\n" + content.trimStart());
       result.updated.push(contextEntryPoint);
       return result;
     },
@@ -295,7 +294,7 @@ export function createRulesOnlyPlugin(config: RulesOnlyPluginConfig): SyncPlugin
     preview(_lockfile: Lockfile, projectRoot: string, _options?: SyncOptions): SyncPreview {
       const filepath = `${projectRoot}/${contextEntryPoint}`;
 
-      if (!existsSync(filepath)) {
+      if (!fs.exists(filepath)) {
         return {
           willCreate: [contextEntryPoint],
           willUpdate: [],


### PR DESCRIPTION
## Summary
- Add crypto provider abstraction (`src/context/crypto.ts`)
- Extend FileSystem interface with `chmod` and `copy` methods
- Refactor 20 files to use context abstractions instead of direct fs/child_process/crypto imports

## Why
~23 files were bypassing the context abstractions and importing I/O directly. This made testing harder and scattered I/O code across the codebase.

## Changes
| Category | Files |
|----------|-------|
| Context | `crypto.ts` (new), `filesystem.ts`, `index.ts` |
| Commands | `init.ts`, `add.ts`, `install.ts`, `list.ts`, `remove.ts`, `version.ts` |
| Config | `project.ts` |
| Artifact | `tarball.ts`, `validation.ts`, `index.ts`, `component-manager.ts`, `check.ts` |
| Registry | `download.ts`, `api-client.ts`, `s3-publisher.ts`, `api-publisher.ts` |
| Sync | `base.ts` |
| Auth | `oauth.ts` |

## Test plan
- [x] `bun run typecheck` passes (only pre-existing errors)
- [x] `bun test` - 176 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)