### PR TITLE
feat: publish install script to releases repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,9 @@ jobs:
           path: artifacts
           merge-multiple: true
 
+      - name: Copy install script to artifacts
+        run: cp scripts/install.sh artifacts/install.sh
+
       - name: Generate Release Notes
         id: notes
         run: |


### PR DESCRIPTION
## Problem

The install script at `grekt.com/install.sh` was serving an outdated/incorrect script (Render CLI installer). 

When users ran:
```bash
curl -fsSL https://grekt.com/install.sh | sh
```

They got Render CLI v2.7.1 instead of grekt.

Root cause: The `scripts/install.sh` in this repo (which correctly installs grekt from `grekt-labs/cli-releases`) was never published to the releases repo, so there was no public URL to redirect to.

## Solution

Extended the GitHub Actions release workflow to automatically publish `scripts/install.sh` as a release asset in `grekt-labs/cli-releases` alongside the platform binaries.

### Changes Made

- Added a single step in the `publish` job (`.github/workflows/release.yml:122-123`)
- Copies `scripts/install.sh` to the artifacts directory before creating the release
- The existing `gh release create artifacts/*` command now uploads `install.sh` with the binaries
- Uses the same `RELEASES_REPO_TOKEN` authentication - no additional config needed

## Result

After this PR is merged and the next release is created, `install.sh` will be publicly available at:

```
https://github.com/grekt-labs/cli-releases/releases/latest/download/install.sh
```

## Next Steps (Post-Merge)

1. Make `grekt-labs/cli-releases` repo public (or make individual releases public)
2. Update Cloudflare to redirect `grekt.com/install.sh` to the GitHub URL above
3. Users can then successfully install grekt via `curl -fsSL https://grekt.com/install.sh | sh`

## Implementation Notes

This is the simplest approach because:
- Reuses existing release creation flow (no separate upload step needed)
- No additional API calls or authentication configuration
- Single line change: `cp scripts/install.sh artifacts/install.sh`
- Automatically included in the batch upload with all other release assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)