### PR TITLE
fix: update imports for cli-engine v5.0.0 API changes

### DIFF
--- a/src/artifact/artifact.ts
+++ b/src/artifact/artifact.ts
@@ -9,7 +9,7 @@ export {
   type ParsedArtifact,
   getSafeFilename,
   toSafeName,
-  getArtifactId,
+  parseName,
   type ArtifactInfo,
   calculateIntegrity,
   type IntegrityResult,

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -6,7 +6,7 @@ import { ARTIFACTS_DIR } from "#/config/paths/paths";
 import { parseSource, downloadFromSource } from "#/registry/sources/sources";
 import { getSourceDisplayName } from "#/registry/registry";
 import { scanArtifact, hashDirectory } from "#/context";
-import { getArtifactId, calculateIntegrity } from "@grekt-labs/cli-engine";
+import { parseName, calculateIntegrity } from "@grekt-labs/cli-engine";
 import { selectComponents, isEmptySelection, isFullSelection, createEmptySelection, type ComponentSelection } from "#/artifact/selector/selector";
 import { removeUnselectedFiles } from "#/artifact/component-manager/component-manager";
 import { generateArtifactIndex } from "#/artifact/index/index";
@@ -99,7 +99,7 @@ export const addCommand = new Command("add")
       process.exit(1);
     }
 
-    const resolvedArtifactId = getArtifactId(artifactInfo.manifest.author, artifactInfo.manifest.name);
+    const resolvedArtifactId = parseName(artifactInfo.manifest.name).artifactId;
 
     // Validate artifact ID to prevent path traversal
     try {

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -4,7 +4,7 @@ import { fs } from "#/context";
 import { parse as parseYaml } from "yaml";
 import {
   ArtifactManifestSchema,
-  getArtifactIdFromManifest,
+  parseName,
   bumpVersion,
   type BumpType,
 } from "@grekt-labs/cli-engine";
@@ -71,7 +71,7 @@ export const versionCommand = new Command("version")
       const manifestContent = fs.readFile(manifestPath);
       const parsed = parseYaml(manifestContent);
       const manifest = ArtifactManifestSchema.parse(parsed);
-      const artifactId = getArtifactIdFromManifest(manifest);
+      const { artifactId } = parseName(manifest.name);
 
       const newVersion = bumpVersion(manifest.version, bump);
 


### PR DESCRIPTION
Replace getArtifactId and getArtifactIdFromManifest with parseName