### PR TITLE
feat(version): add prerelease --beta support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "grekt",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.971.0",
-        "@grekt-labs/cli-engine": "^5.0.0",
+        "@grekt-labs/cli-engine": "^5.1.0",
         "@inquirer/prompts": "^7.2.0",
         "@supabase/supabase-js": "^2.91.0",
         "chalk": "^5.4.1",
@@ -123,7 +123,7 @@
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
-    "@grekt-labs/cli-engine": ["@grekt-labs/cli-engine@5.0.0", "https://npm.pkg.github.com/download/@grekt-labs/cli-engine/5.0.0/d1ae3241d8e4fecafe95880e29ca98530c879871", { "dependencies": { "gray-matter": "^4.0.3", "semver": "^7.7.3", "yaml": "^2.6.1", "zod": "^3.24.1" } }, "sha512-2PeIpjw91fP7BchPT0aOTIRyV9TvN0rUeA3NQLrQY7qlCb5k6DE5z0hqijbgPI+XMdOABVZxlfppwIfHQ0JWgA=="],
+    "@grekt-labs/cli-engine": ["@grekt-labs/cli-engine@5.1.0", "https://npm.pkg.github.com/download/@grekt-labs/cli-engine/5.1.0/efe5001647d598492c244c03e32fe3da800409f6", { "dependencies": { "gray-matter": "^4.0.3", "semver": "^7.7.3", "yaml": "^2.6.1", "zod": "^3.24.1" } }, "sha512-mkIuvv914m6eh+IZVM3x2xHUcT3FNCOwIXwlCyye+qCiLHCQshXzfgvHFJ3slqRebJDzvEtD7BevVxOZRiW5OA=="],
 
     "@inquirer/ansi": ["@inquirer/ansi@1.0.2", "", {}, "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="],
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.971.0",
-    "@grekt-labs/cli-engine": "^5.0.0",
+    "@grekt-labs/cli-engine": "^5.1.0",
     "@inquirer/prompts": "^7.2.0",
     "@supabase/supabase-js": "^2.91.0",
     "chalk": "^5.4.1",

--- a/src/commands/remove-target.ts
+++ b/src/commands/remove-target.ts
@@ -3,7 +3,7 @@ import { confirm } from "@inquirer/prompts";
 import { isInitialized, getConfig, saveConfig } from "#/config/project/project";
 import { getPluginChoices } from "#/sync/manager/manager";
 import { cleanTargetPaths } from "#/sync/cleaner/cleaner";
-import { success, error, info, newline, warn } from "#/shared/ui/ui";
+import { success, error, info, newline, warning } from "#/shared/ui/ui";
 import { withPromptHandler, selectTargetsToRemove } from "#/shared/prompts/prompts";
 
 export const removeTargetCommand = new Command("remove-target")
@@ -21,7 +21,7 @@ export const removeTargetCommand = new Command("remove-target")
       const config = getConfig(projectRoot);
 
       if (config.targets.length === 0) {
-        warn("No targets configured");
+        warning("No targets configured");
         info("Run 'grekt add-target' to add targets");
         return;
       }

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -6,38 +6,51 @@ import {
   ArtifactManifestSchema,
   parseName,
   bumpVersion,
+  bumpPrerelease,
   type BumpType,
 } from "@grekt-labs/cli-engine";
 import { success, error, info, log, colors } from "#/shared/ui/ui";
 
 const MANIFEST_FILE = "grekt.yaml";
-const BUMP_TYPES = ["patch", "minor", "major"] as const;
+const BUMP_TYPES = ["patch", "minor", "major", "prerelease"] as const;
+const PRERELEASE_IDENTIFIER = "beta";
+
+type ExtendedBumpType = BumpType | "prerelease";
 
 interface VersionCommandOptions {
   dryRun?: boolean;
+  beta?: boolean;
 }
 
-function isBumpType(value: string): value is BumpType {
-  return BUMP_TYPES.includes(value as BumpType);
+function isValidBumpType(value: string): value is ExtendedBumpType {
+  return BUMP_TYPES.includes(value as ExtendedBumpType);
 }
 
 export const versionCommand = new Command("version")
-  .description("Bump artifact versions (patch, minor, major)")
-  .argument("[bump]", "Bump type: patch, minor, or major")
+  .description("Bump artifact versions (patch, minor, major, prerelease)")
+  .argument("[bump]", "Bump type: patch, minor, major, or prerelease")
   .argument("[path]", "Path to artifact or directory containing artifacts", ".")
   .option("--dry-run", "Show what would happen without applying changes")
+  .option("--beta", "Use beta identifier for prerelease (required with prerelease)")
   .action(async (bump: string | undefined, targetPath: string, options: VersionCommandOptions) => {
     if (!bump) {
       error("Bump type required. Usage:");
       info("  grekt version patch");
       info("  grekt version minor");
       info("  grekt version major");
+      info("  grekt version prerelease --beta");
       process.exit(1);
     }
 
-    if (!isBumpType(bump)) {
+    if (!isValidBumpType(bump)) {
       error(`Invalid bump type: ${bump}`);
-      info("Use: patch, minor, or major");
+      info("Use: patch, minor, major, or prerelease");
+      process.exit(1);
+    }
+
+    if (bump === "prerelease" && !options.beta) {
+      error("Prerelease requires --beta flag");
+      info("Usage: grekt version prerelease --beta");
       process.exit(1);
     }
 
@@ -73,7 +86,9 @@ export const versionCommand = new Command("version")
       const manifest = ArtifactManifestSchema.parse(parsed);
       const { artifactId } = parseName(manifest.name);
 
-      const newVersion = bumpVersion(manifest.version, bump);
+      const newVersion = bump === "prerelease"
+        ? bumpPrerelease(manifest.version, PRERELEASE_IDENTIFIER)
+        : bumpVersion(manifest.version, bump);
 
       log(`  ${artifactId}: ${manifest.version} → ${newVersion}`);
 


### PR DESCRIPTION
## Summary
- Add `grekt version prerelease --beta` command for beta version bumps
- Update cli-engine to 5.1.0 (includes `bumpPrerelease` function)
- Fix `warning` import in remove-target command

## Usage
```bash
grekt version prerelease --beta

# Examples:
# 1.0.0 → 1.0.1-beta.0
# 1.0.1-beta.0 → 1.0.1-beta.1
# 1.0.1-beta.1 → 1.0.1-beta.2
```

## Test plan
- [x] Build passes
- [x] Version command tests pass