### PR TITLE
fix(cleaner): prevent deletion of dangerous paths

### DIFF
--- a/src/sync/cleaner/cleaner.test.ts
+++ b/src/sync/cleaner/cleaner.test.ts
@@ -177,4 +177,140 @@ describe("cleaner", () => {
       expect(result.deleted).toContain("config.md");
     });
   });
+
+  describe("security: dangerous path protection", () => {
+    test("does NOT delete project root when targetDir resolves to '.'", () => {
+      const testFile = join(testDir, "important.txt");
+      writeFileSync(testFile, "do not delete me");
+
+      const customTargets = {
+        dangerous: {
+          name: "Dangerous",
+          contextEntryPoint: "INSTRUCTIONS.md",
+          paths: {
+            agents: "agents",
+          },
+        },
+      };
+
+      const result = cleanTargetPaths(testDir, "dangerous", customTargets);
+
+      expect(existsSync(testDir)).toBe(true);
+      expect(existsSync(testFile)).toBe(true);
+      expect(result.deleted).not.toContain(".");
+      expect(result.deleted).toHaveLength(0);
+    });
+
+    test("does NOT delete parent directory with '..' path", () => {
+      const customTargets = {
+        "evil-target": {
+          name: "Evil",
+          contextEntryPoint: "../outside.md",
+          paths: {
+            agents: "agents",
+          },
+        },
+      };
+
+      const result = cleanTargetPaths(testDir, "evil-target", customTargets);
+
+      expect(existsSync(testDir)).toBe(true);
+      expect(result.deleted).not.toContain("..");
+    });
+
+    test("does NOT delete paths outside project root (path traversal)", () => {
+      const customTargets = {
+        "traversal-target": {
+          name: "Traversal",
+          contextEntryPoint: "../../etc/passwd",
+          paths: {
+            agents: "agents",
+          },
+        },
+      };
+
+      const result = cleanTargetPaths(testDir, "traversal-target", customTargets);
+
+      expect(result.deleted).toHaveLength(0);
+    });
+
+    test("does NOT delete when custom target contextEntryPoint is root-level file", () => {
+      // This was the original bug: dirname("INSTRUCTIONS.md") returns "."
+      const testFile = join(testDir, "important.txt");
+      writeFileSync(testFile, "do not delete me");
+
+      const customTargets = {
+        codex: {
+          name: "Codex",
+          contextEntryPoint: "INSTRUCTIONS.md",
+          paths: {
+            agents: ".codex/agents",
+          },
+        },
+      };
+
+      const result = cleanTargetPaths(testDir, "codex", customTargets);
+
+      // dirname("INSTRUCTIONS.md") = "." which should be normalized to ""
+      // and then rejected as dangerous
+      expect(existsSync(testDir)).toBe(true);
+      expect(existsSync(testFile)).toBe(true);
+    });
+
+    test("safely deletes valid nested directory", () => {
+      const nestedDir = join(testDir, ".safe-target");
+      mkdirSync(nestedDir, { recursive: true });
+      writeFileSync(join(nestedDir, "config.md"), "content");
+
+      const customTargets = {
+        "safe-target": {
+          name: "Safe Target",
+          contextEntryPoint: ".safe-target/config.md",
+          paths: {
+            agents: ".safe-target/agents",
+          },
+        },
+      };
+
+      const result = cleanTargetPaths(testDir, "safe-target", customTargets);
+
+      expect(existsSync(nestedDir)).toBe(false);
+      expect(result.deleted).toContain(".safe-target");
+    });
+  });
+
+  describe("getTargetPaths: dirname normalization", () => {
+    test("normalizes '.' to empty string for root-level contextEntryPoint", () => {
+      const customTargets = {
+        "root-file-target": {
+          name: "Root File",
+          contextEntryPoint: "INSTRUCTIONS.md",
+          paths: {
+            agents: "agents",
+          },
+        },
+      };
+
+      const paths = getTargetPaths("root-file-target", customTargets);
+
+      // dirname("INSTRUCTIONS.md") returns "." but should be normalized to ""
+      expect(paths?.targetDir).toBe("");
+    });
+
+    test("preserves valid directory from dirname", () => {
+      const customTargets = {
+        "nested-target": {
+          name: "Nested",
+          contextEntryPoint: ".nested/config.md",
+          paths: {
+            agents: ".nested/agents",
+          },
+        },
+      };
+
+      const paths = getTargetPaths("nested-target", customTargets);
+
+      expect(paths?.targetDir).toBe(".nested");
+    });
+  });
 });

--- a/src/sync/cleaner/cleaner.ts
+++ b/src/sync/cleaner/cleaner.ts
@@ -1,10 +1,34 @@
-import { dirname, join } from "path";
+import { dirname, join, resolve } from "path";
 import { fs } from "#/context";
 import type { CustomTarget } from "@grekt-labs/cli-engine";
 
 export interface TargetPaths {
   targetDir: string;
   contextEntryPoint: string;
+}
+
+const DANGEROUS_PATHS = new Set([".", "..", "/", ""]);
+
+/**
+ * Check if a path is safe to delete (not root, not project root, not dangerous).
+ */
+function isSafeToDelete(projectRoot: string, relativePath: string): boolean {
+  if (DANGEROUS_PATHS.has(relativePath)) {
+    return false;
+  }
+
+  const absolutePath = resolve(projectRoot, relativePath);
+  const normalizedProjectRoot = resolve(projectRoot);
+
+  if (absolutePath === normalizedProjectRoot) {
+    return false;
+  }
+
+  if (!absolutePath.startsWith(normalizedProjectRoot + "/")) {
+    return false;
+  }
+
+  return true;
 }
 
 const builtInTargetPaths: Record<string, TargetPaths> = {
@@ -36,9 +60,14 @@ export function getTargetPaths(
 
   const customTarget = customTargets?.[targetId];
   if (customTarget) {
-    const targetDir = customTarget.paths
+    let targetDir = customTarget.paths
       ? dirname(customTarget.contextEntryPoint)
       : targetId;
+
+    // dirname returns "." for root-level files, treat as no directory
+    if (targetDir === ".") {
+      targetDir = "";
+    }
 
     return {
       targetDir,
@@ -71,8 +100,8 @@ export function cleanTargetPaths(
 
   const { targetDir, contextEntryPoint } = paths;
 
-  // Delete target directory if it exists
-  if (targetDir) {
+  // Delete target directory if it exists and is safe
+  if (targetDir && isSafeToDelete(projectRoot, targetDir)) {
     const fullPath = join(projectRoot, targetDir);
     if (fs.exists(fullPath)) {
       fs.rmdir(fullPath, { recursive: true });
@@ -82,8 +111,8 @@ export function cleanTargetPaths(
     }
   }
 
-  // Delete context entry point if it's outside the target directory
-  if (contextEntryPoint) {
+  // Delete context entry point if it's outside the target directory and is safe
+  if (contextEntryPoint && isSafeToDelete(projectRoot, contextEntryPoint)) {
     const isInsideTargetDir = targetDir && contextEntryPoint.startsWith(targetDir + "/");
 
     if (!isInsideTargetDir) {


### PR DESCRIPTION
## Summary
- Add `isSafeToDelete()` validation to prevent catastrophic deletions
- Reject dangerous paths: `.`, `..`, `/`, empty strings
- Reject paths that resolve to or escape the project root
- Normalize `dirname(".")` to empty string for root-level files

## Context
The `remove-target` command with "Delete folders" option could delete the entire project root when a custom target had a root-level `contextEntryPoint` (e.g., `INSTRUCTIONS.md`), because `dirname("INSTRUCTIONS.md")` returns `.` which resolved to the project root.

## Test plan
- [x] Added tests for dangerous path rejection (`.`, `..`, path traversal)
- [x] Added tests for dirname normalization
- [x] All 225 tests pass