### PR TITLE
feat(workspace): add monorepo workspace support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,11 +6,12 @@
       "name": "grekt",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.971.0",
-        "@grekt-labs/cli-engine": "^5.1.0",
+        "@grekt-labs/cli-engine": "^5.2.0",
         "@inquirer/prompts": "^7.2.0",
         "@supabase/supabase-js": "^2.91.0",
         "chalk": "^5.4.1",
         "commander": "^12.1.0",
+        "fast-glob": "^3.3.3",
         "gray-matter": "^4.0.3",
         "ora": "^8.1.1",
         "yaml": "^2.6.1",
@@ -123,7 +124,7 @@
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
-    "@grekt-labs/cli-engine": ["@grekt-labs/cli-engine@5.1.0", "https://npm.pkg.github.com/download/@grekt-labs/cli-engine/5.1.0/efe5001647d598492c244c03e32fe3da800409f6", { "dependencies": { "gray-matter": "^4.0.3", "semver": "^7.7.3", "yaml": "^2.6.1", "zod": "^3.24.1" } }, "sha512-mkIuvv914m6eh+IZVM3x2xHUcT3FNCOwIXwlCyye+qCiLHCQshXzfgvHFJ3slqRebJDzvEtD7BevVxOZRiW5OA=="],
+    "@grekt-labs/cli-engine": ["@grekt-labs/cli-engine@5.2.0", "https://npm.pkg.github.com/download/@grekt-labs/cli-engine/5.2.0/0ad01315ba657e9472123448d3eda74ab5d6b326", { "dependencies": { "gray-matter": "^4.0.3", "semver": "^7.7.3", "yaml": "^2.6.1", "zod": "^3.24.1" } }, "sha512-upaBuvcgn2P2cy1141OhmBFDvRfblgM6q0a1usqVsykccIF+1NlKxuulZiMSUeLlQ2HZL0DNOzIueOwrmlTHDg=="],
 
     "@inquirer/ansi": ["@inquirer/ansi@1.0.2", "", {}, "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="],
 
@@ -156,6 +157,12 @@
     "@inquirer/select": ["@inquirer/select@4.4.2", "", { "dependencies": { "@inquirer/ansi": "1.0.2", "@inquirer/core": "10.3.2", "@inquirer/figures": "1.0.15", "@inquirer/type": "3.0.10", "yoctocolors-cjs": "2.1.3" }, "optionalDependencies": { "@types/node": "22.19.7" } }, "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w=="],
 
     "@inquirer/type": ["@inquirer/type@3.0.10", "", { "optionalDependencies": { "@types/node": "22.19.7" } }, "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA=="],
+
+    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
+
+    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
+
+    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@octokit/auth-token": ["@octokit/auth-token@6.0.0", "", {}, "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="],
 
@@ -439,7 +446,11 @@
 
     "fast-content-type-parse": ["fast-content-type-parse@3.0.0", "", {}, "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg=="],
 
+    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
     "fast-xml-parser": ["fast-xml-parser@5.2.5", "", { "dependencies": { "strnum": "^2.1.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ=="],
+
+    "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -466,6 +477,8 @@
     "get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
 
     "git-log-parser": ["git-log-parser@1.2.1", "", { "dependencies": { "argv-formatter": "~1.0.0", "spawn-error-forwarder": "~1.0.0", "split2": "~1.0.0", "stream-combiner2": "~1.1.1", "through2": "~2.0.0", "traverse": "0.6.8" } }, "sha512-PI+sPDvHXNPl5WNOErAK05s3j0lgwUzMN6o8cyQrDaKfT3qd7TmNJKeXX+SknI5I0QhG5fVPAEwSY4tRGDtYoQ=="],
+
+    "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
@@ -511,7 +524,11 @@
 
     "is-extendable": ["is-extendable@0.1.1", "", {}, "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="],
 
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-interactive": ["is-interactive@2.0.0", "", {}, "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ=="],
 
@@ -578,6 +595,8 @@
     "meow": ["meow@13.2.0", "", {}, "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA=="],
 
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
+
+    "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
@@ -665,6 +684,8 @@
 
     "proto-list": ["proto-list@1.2.4", "", {}, "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="],
 
+    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
     "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
     "read-package-up": ["read-package-up@12.0.0", "", { "dependencies": { "find-up-simple": "^1.0.1", "read-pkg": "^10.0.0", "type-fest": "^5.2.0" } }, "sha512-Q5hMVBYur/eQNWDdbF4/Wqqr9Bjvtrw2kjGxxBbKLbx8bVCL8gcArjTy8zDUuLGQicftpMuU0riQNcAsbtOVsw=="],
@@ -680,6 +701,10 @@
     "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
 
     "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "7.0.0", "signal-exit": "4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
+
+    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 

--- a/package.json
+++ b/package.json
@@ -26,11 +26,12 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.971.0",
-    "@grekt-labs/cli-engine": "^5.1.0",
+    "@grekt-labs/cli-engine": "^5.2.0",
     "@inquirer/prompts": "^7.2.0",
     "@supabase/supabase-js": "^2.91.0",
     "chalk": "^5.4.1",
     "commander": "^12.1.0",
+    "fast-glob": "^3.3.3",
     "gray-matter": "^4.0.3",
     "ora": "^8.1.1",
     "yaml": "^2.6.1",

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -9,16 +9,26 @@ import { S3Publisher } from "#/registry/publishers/s3-publisher";
 import { CustomPublisher } from "#/registry/publishers/custom-publisher";
 import { isApiAuthenticated } from "#/registry/publishers/api-publisher";
 import type { PublishContext } from "#/registry/publishers/publisher.types";
+import type { Publisher } from "#/registry/publishers/publisher.types";
 import { createTarball, removeTarball } from "#/artifact/tarball/tarball";
 import { validateArtifact } from "#/artifact/validation/validation";
-import { CATEGORIES, generateComponents } from "@grekt-labs/cli-engine";
+import {
+  CATEGORIES,
+  generateComponents,
+  isWorkspaceRoot,
+  compareSemver,
+} from "@grekt-labs/cli-engine";
 import { success, error, info, log, colors, spinner } from "#/shared/ui/ui";
+import { loadWorkspace } from "./workspace";
+import { fs } from "#/context";
 
 const MIN_KEYWORDS = 3;
 const MAX_KEYWORDS = 5;
 
 interface PublishOptions {
   s3?: boolean;
+  changed?: boolean;
+  dryRun?: boolean;
 }
 
 function logComponentSummary(
@@ -64,44 +74,167 @@ export const publishCommand = new Command("publish")
   .description("Publish an artifact to a registry")
   .argument("[path]", "Path to artifact directory (default: current directory)", ".")
   .option("--s3", "Use S3-compatible storage (legacy mode, env vars only)")
+  .option("--changed", "Publish only artifacts with version > registry (workspace mode)")
+  .option("--dry-run", "Show what would be published without actually publishing")
   .action(async (artifactPath: string, options: PublishOptions) => {
-    const projectRoot = process.cwd();
+    const cwd = process.cwd();
 
-    const result = validateArtifact(artifactPath, projectRoot, {
-      requireKeywords: { min: MIN_KEYWORDS, max: MAX_KEYWORDS },
+    // --changed mode: publish all workspace artifacts where local > registry
+    if (options.changed) {
+      await handleChangedMode(cwd, options);
+      return;
+    }
+
+    // Standard single artifact publish
+    await publishSingleArtifact(artifactPath, cwd, options);
+  });
+
+/**
+ * Handle --changed mode: publish workspace artifacts where local version > registry.
+ */
+async function handleChangedMode(cwd: string, options: PublishOptions): Promise<void> {
+  if (!isWorkspaceRoot(fs, cwd)) {
+    error("--changed requires a workspace (grekt-workspace.yaml not found)");
+    info("Run this command from your workspace root");
+    process.exit(1);
+  }
+
+  const workspace = await loadWorkspace(cwd);
+
+  if (!workspace || workspace.artifacts.length === 0) {
+    error("No artifacts found in workspace");
+    process.exit(1);
+  }
+
+  log("");
+  info(`Checking ${workspace.artifacts.length} artifact(s) for changes...`);
+  log("");
+
+  const toPublish: Array<{ path: string; name: string; localVersion: string; registryVersion: string | null }> = [];
+
+  for (const artifact of workspace.artifacts) {
+    const publisher = createPublisher({
+      s3: options.s3,
+      scope: artifact.manifest.name.split("/")[0]!,
+      projectRoot: cwd,
     });
 
-    if (!result.success) {
-      error(result.error.message);
-      if (result.error.details) {
-        for (const detail of result.error.details) {
-          info(detail);
-        }
-      }
-      if (result.error.type === "keywords") {
-        showKeywordsExample();
-      }
-      if (result.error.type === "no-components") {
-        showFrontmatterExample();
-      }
-      process.exit(1);
+    let registryVersion: string | null = null;
+
+    try {
+      registryVersion = await publisher.getLatestVersion({
+        artifactId: artifact.manifest.name,
+        version: artifact.manifest.version,
+        tarballPath: "",
+        scope: artifact.manifest.name.split("/")[0]!,
+        projectRoot: cwd,
+      });
+    } catch {
+      // Artifact not published yet
     }
 
-    const { artifact } = result;
+    const localVersion = artifact.manifest.version;
+    const needsPublish = !registryVersion || compareSemver(localVersion, registryVersion) > 0;
 
-    // Verify artifact has a scope (required for publishing)
-    if (!artifact.scope) {
-      error("Cannot publish: artifact name must include scope");
-      log("");
-      info("Update your grekt.yaml:");
-      log(colors.dim("  name: \"@your-scope/artifact-name\""));
-      log("");
-      log(colors.dim("The scope determines which registry to use for publishing."));
-      process.exit(1);
+    if (needsPublish) {
+      toPublish.push({
+        path: artifact.path,
+        name: artifact.manifest.name,
+        localVersion,
+        registryVersion,
+      });
+      log(`  ${colors.green("↑")} ${artifact.manifest.name} ${localVersion} ${registryVersion ? `(registry: ${registryVersion})` : "(new)"}`);
+    } else {
+      log(`  ${colors.dim("=")} ${artifact.manifest.name} ${localVersion} (up to date)`);
     }
+  }
 
-    setProjectRoot(projectRoot);
+  log("");
 
+  if (toPublish.length === 0) {
+    info("All artifacts are up to date");
+    return;
+  }
+
+  info(`${toPublish.length} artifact(s) to publish`);
+
+  if (options.dryRun) {
+    log("");
+    info("Dry run complete (no artifacts were published)");
+    return;
+  }
+
+  log("");
+
+  let published = 0;
+  let failed = 0;
+
+  for (const item of toPublish) {
+    try {
+      await publishSingleArtifact(item.path, cwd, { s3: options.s3 }, true);
+      published++;
+    } catch (err) {
+      failed++;
+      const message = err instanceof Error ? err.message : "Unknown error";
+      error(`Failed to publish ${item.name}: ${message}`);
+    }
+  }
+
+  log("");
+  if (published > 0) {
+    success(`Published ${published} artifact(s)`);
+  }
+  if (failed > 0) {
+    error(`Failed to publish ${failed} artifact(s)`);
+    process.exit(1);
+  }
+}
+
+/**
+ * Publish a single artifact.
+ */
+async function publishSingleArtifact(
+  artifactPath: string,
+  projectRoot: string,
+  options: { s3?: boolean },
+  silent: boolean = false
+): Promise<void> {
+  const result = validateArtifact(artifactPath, projectRoot, {
+    requireKeywords: { min: MIN_KEYWORDS, max: MAX_KEYWORDS },
+  });
+
+  if (!result.success) {
+    error(result.error.message);
+    if (result.error.details) {
+      for (const detail of result.error.details) {
+        info(detail);
+      }
+    }
+    if (result.error.type === "keywords") {
+      showKeywordsExample();
+    }
+    if (result.error.type === "no-components") {
+      showFrontmatterExample();
+    }
+    throw new Error(result.error.message);
+  }
+
+  const { artifact } = result;
+
+  // Verify artifact has a scope (required for publishing)
+  if (!artifact.scope) {
+    error("Cannot publish: artifact name must include scope");
+    log("");
+    info("Update your grekt.yaml:");
+    log(colors.dim("  name: \"@your-scope/artifact-name\""));
+    log("");
+    log(colors.dim("The scope determines which registry to use for publishing."));
+    throw new Error("No scope");
+  }
+
+  setProjectRoot(projectRoot);
+
+  if (!silent) {
     logComponentSummary(
       artifact.artifactId,
       artifact.manifest.version,
@@ -109,85 +242,56 @@ export const publishCommand = new Command("publish")
       artifact.scanned,
       artifact.componentCount
     );
+  }
 
-    const components = generateComponents(artifact.scanned);
+  const components = generateComponents(artifact.scanned);
 
-    const tarballResult = createTarball({
-      artifactPath: artifact.fullPath,
-      artifactId: artifact.artifactId,
-      projectRoot,
-      components,
-    });
+  const tarballResult = createTarball({
+    artifactPath: artifact.fullPath,
+    artifactId: artifact.artifactId,
+    projectRoot,
+    components,
+  });
 
-    if (!tarballResult.success || !tarballResult.path) {
-      error(`Failed to create tarball: ${tarballResult.error}`);
-      process.exit(1);
-    }
+  if (!tarballResult.success || !tarballResult.path) {
+    throw new Error(`Failed to create tarball: ${tarballResult.error}`);
+  }
 
+  if (!silent) {
     success(`Created tarball: ${tarballResult.filename}`);
+  }
 
-    const publisher = createPublisher({
-      s3: options.s3,
-      scope: artifact.scope,
-      projectRoot,
-    });
+  const publisher = createPublisher({
+    s3: options.s3,
+    scope: artifact.scope,
+    projectRoot,
+  });
 
-    const ctx: PublishContext = {
-      artifactId: artifact.artifactId,
-      version: artifact.manifest.version,
-      tarballPath: tarballResult.path,
-      scope: artifact.scope,
-      projectRoot,
-    };
+  const ctx: PublishContext = {
+    artifactId: artifact.artifactId,
+    version: artifact.manifest.version,
+    tarballPath: tarballResult.path,
+    scope: artifact.scope,
+    projectRoot,
+  };
 
-    if (publisher instanceof S3Publisher && !publisher.hasCredentials()) {
+  if (publisher instanceof S3Publisher && !publisher.hasCredentials()) {
+    removeTarball(tarballResult.path);
+    showS3CredentialsHelp();
+    throw new Error("No S3 credentials");
+  }
+
+  // Check if using default registry (no config found for this scope)
+  if (publisher.type === "api") {
+    const authenticated = await isApiAuthenticated();
+    if (!authenticated) {
       removeTarball(tarballResult.path);
-      showS3CredentialsHelp();
-      process.exit(1);
+      showRegistryConfigHelp(artifact.scope, projectRoot);
+      throw new Error("Not authenticated");
     }
+  }
 
-    // Check if using default registry (no config found for this scope)
-    if (publisher.type === "api") {
-      const authenticated = await isApiAuthenticated();
-      if (!authenticated) {
-        removeTarball(tarballResult.path);
-
-        // Check if there are other registries configured (possible typo)
-        const localConfig = getLocalConfig(projectRoot);
-        const configuredScopes = localConfig?.registries
-          ? Object.keys(localConfig.registries)
-          : [];
-
-        if (configuredScopes.length > 0) {
-          // User has registries configured, but not for this scope
-          error(`No registry configured for ${artifact.scope}`);
-          log("");
-          info("Available registries:");
-          for (const scope of configuredScopes) {
-            const entry = localConfig!.registries![scope];
-            log(`  ${scope} (${entry.type})`);
-          }
-          log("");
-          log(colors.dim(`Check if your artifact scope matches your config.`));
-          log(colors.dim(`Config file: ${getLocalConfigPath(projectRoot)}`));
-        } else {
-          // No registries configured at all
-          error(`No registry configured for ${artifact.scope}`);
-          log("");
-          info(`Add a registry to ${getLocalConfigPath(projectRoot)}:`);
-          log(colors.dim("  registries:"));
-          log(colors.dim(`    \"${artifact.scope}\":`));
-          log(colors.dim("      type: gitlab"));
-          log(colors.dim("      project: your-group/your-project"));
-          log(colors.dim("      token: your-token"));
-          log("");
-          log(colors.dim("For S3-compatible storage, use --s3 flag"));
-        }
-
-        process.exit(1);
-      }
-    }
-
+  if (!silent) {
     const checkSpin = spinner("Checking if version exists...");
     checkSpin.start();
 
@@ -199,46 +303,52 @@ export const publishCommand = new Command("publish")
         removeTarball(tarballResult.path);
         error(`Version ${artifact.manifest.version} already exists for ${artifact.artifactId}`);
         info("Bump the version in grekt.yaml and try again");
-        process.exit(1);
+        throw new Error("Version exists");
       }
     } catch (err) {
       checkSpin.stop();
+      if (err instanceof Error && err.message === "Version exists") {
+        throw err;
+      }
       // Version check failed, but we continue with publish attempt
-      // The publish step will provide a more specific error if there's an issue
       const message = err instanceof Error ? err.message : "Unknown error";
       info(`Could not verify version existence: ${message}`);
     }
+  }
 
-    const publisherName = getPublisherTypeName(publisher);
-    const spin = spinner(`Publishing to ${publisherName}...`);
-    spin.start();
+  const publisherName = getPublisherTypeName(publisher);
+  const spin = silent ? null : spinner(`Publishing to ${publisherName}...`);
+  spin?.start();
 
-    const publishResult = await publisher.publish(ctx);
-    spin.stop();
+  const publishResult = await publisher.publish(ctx);
+  spin?.stop();
 
-    if (!publishResult.success) {
-      removeTarball(tarballResult.path);
-      error(`Publish failed: ${publishResult.error}`);
-
-      if (publisher instanceof CustomPublisher) {
-        const registry = publisher.getRegistry();
-        if (registry.type === "gitlab" && !registry.token) {
-          showGitLabHelp(artifact.scope, projectRoot);
-        }
-      }
-
-      process.exit(1);
-    }
-
+  if (!publishResult.success) {
     removeTarball(tarballResult.path);
 
+    if (publisher instanceof CustomPublisher) {
+      const registry = publisher.getRegistry();
+      if (registry.type === "gitlab" && !registry.token) {
+        showGitLabHelp(artifact.scope, projectRoot);
+      }
+    }
+
+    throw new Error(`Publish failed: ${publishResult.error}`);
+  }
+
+  removeTarball(tarballResult.path);
+
+  if (!silent) {
     log("");
     success(`Published ${artifact.artifactId}@${artifact.manifest.version}`);
     if (publishResult.url) {
       log(`  URL: ${publishResult.url}`);
     }
     log(`\n  Install with: grekt add ${artifact.artifactId}@${artifact.manifest.version}\n`);
-  });
+  } else {
+    success(`Published ${artifact.artifactId}@${artifact.manifest.version}`);
+  }
+}
 
 function showS3CredentialsHelp(): void {
   error("No S3 credentials found");
@@ -252,6 +362,37 @@ function showS3CredentialsHelp(): void {
   log("  GREKT_STORAGE_PUBLIC_URL=https://... (optional)");
   log("");
   log(colors.dim("Use 'grekt pack' to create tarball without uploading"));
+}
+
+function showRegistryConfigHelp(scope: string | null, projectRoot: string): void {
+  const localConfig = getLocalConfig(projectRoot);
+  const configuredScopes = localConfig?.registries
+    ? Object.keys(localConfig.registries)
+    : [];
+
+  if (configuredScopes.length > 0) {
+    error(`No registry configured for ${scope}`);
+    log("");
+    info("Available registries:");
+    for (const s of configuredScopes) {
+      const entry = localConfig!.registries![s];
+      log(`  ${s} (${entry.type})`);
+    }
+    log("");
+    log(colors.dim(`Check if your artifact scope matches your config.`));
+    log(colors.dim(`Config file: ${getLocalConfigPath(projectRoot)}`));
+  } else {
+    error(`No registry configured for ${scope}`);
+    log("");
+    info(`Add a registry to ${getLocalConfigPath(projectRoot)}:`);
+    log(colors.dim("  registries:"));
+    log(colors.dim(`    \"${scope}\":`));
+    log(colors.dim("      type: gitlab"));
+    log(colors.dim("      project: your-group/your-project"));
+    log(colors.dim("      token: your-token"));
+    log("");
+    log(colors.dim("For S3-compatible storage, use --s3 flag"));
+  }
 }
 
 function showGitLabHelp(scope: string | null, projectRoot: string): void {

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { join, resolve } from "path";
+import { spawnSync } from "child_process";
 import { fs } from "#/context";
 import { parse as parseYaml } from "yaml";
 import {
@@ -7,9 +8,16 @@ import {
   parseName,
   bumpVersion,
   bumpPrerelease,
+  isWorkspaceRoot,
   type BumpType,
 } from "@grekt-labs/cli-engine";
-import { success, error, info, log, colors } from "#/shared/ui/ui";
+import { success, error, info, log, colors, spinner } from "#/shared/ui/ui";
+import {
+  loadWorkspace,
+  generatePackageJsonFiles,
+  syncVersionsToManifest,
+  cleanPackageJsonFiles,
+} from "./workspace";
 
 const MANIFEST_FILE = "grekt.yaml";
 const BUMP_TYPES = ["patch", "minor", "major", "prerelease"] as const;
@@ -20,6 +28,7 @@ type ExtendedBumpType = BumpType | "prerelease";
 interface VersionCommandOptions {
   dryRun?: boolean;
   beta?: boolean;
+  exec?: string;
 }
 
 function isValidBumpType(value: string): value is ExtendedBumpType {
@@ -32,13 +41,26 @@ export const versionCommand = new Command("version")
   .argument("[path]", "Path to artifact or directory containing artifacts", ".")
   .option("--dry-run", "Show what would happen without applying changes")
   .option("--beta", "Use beta identifier for prerelease (required with prerelease)")
+  .option("--exec <command>", "Run external versioning command (generates temp package.json for compatibility)")
   .action(async (bump: string | undefined, targetPath: string, options: VersionCommandOptions) => {
+    const cwd = process.cwd();
+
+    // --exec mode: delegate to external tool with package.json compatibility
+    if (options.exec) {
+      await handleExecMode(cwd, options.exec, options.dryRun);
+      return;
+    }
+
+    // Standard bump mode
     if (!bump) {
       error("Bump type required. Usage:");
       info("  grekt version patch");
       info("  grekt version minor");
       info("  grekt version major");
       info("  grekt version prerelease --beta");
+      info("");
+      info("Or use external versioning tool:");
+      info("  grekt version --exec \"npx changeset version\"");
       process.exit(1);
     }
 
@@ -110,6 +132,97 @@ export const versionCommand = new Command("version")
       success(`Updated ${updated} artifact(s)`);
     }
   });
+
+/**
+ * Handle --exec mode: generate package.json, run command, sync back, cleanup.
+ */
+async function handleExecMode(cwd: string, command: string, dryRun?: boolean): Promise<void> {
+  if (!isWorkspaceRoot(fs, cwd)) {
+    error("--exec requires a workspace (grekt-workspace.yaml not found)");
+    info("Run this command from your workspace root");
+    process.exit(1);
+  }
+
+  const workspace = await loadWorkspace(cwd);
+
+  if (!workspace || workspace.artifacts.length === 0) {
+    error("No artifacts found in workspace");
+    process.exit(1);
+  }
+
+  log("");
+  info(`Workspace: ${workspace.artifacts.length} artifact(s)`);
+
+  if (dryRun) {
+    log(colors.dim("  (dry-run mode - no changes will be made)"));
+    log("");
+    info("Would generate package.json files for:");
+    for (const artifact of workspace.artifacts) {
+      log(`  ${artifact.manifest.name} ${colors.dim(`v${artifact.manifest.version}`)}`);
+    }
+    log("");
+    info(`Would run: ${command}`);
+    return;
+  }
+
+  // Step 1: Generate package.json files
+  const genSpin = spinner("Generating package.json files...");
+  genSpin.start();
+  generatePackageJsonFiles(workspace.artifacts);
+  genSpin.stop();
+  success(`Generated ${workspace.artifacts.length} package.json file(s)`);
+
+  // Step 2: Run external command
+  log("");
+  info(`Running: ${command}`);
+  log("");
+
+  const result = spawnSync(command, {
+    shell: true,
+    cwd,
+    stdio: "inherit",
+  });
+
+  if (result.status !== 0) {
+    // Cleanup on failure
+    cleanPackageJsonFiles(workspace.artifacts);
+    error(`Command failed with exit code ${result.status}`);
+    process.exit(result.status ?? 1);
+  }
+
+  // Step 3: Sync versions back to grekt.yaml
+  log("");
+  const syncSpin = spinner("Syncing versions to grekt.yaml...");
+  syncSpin.start();
+
+  // Reload workspace to get updated artifacts
+  const updatedWorkspace = await loadWorkspace(cwd);
+  if (!updatedWorkspace) {
+    syncSpin.stop();
+    cleanPackageJsonFiles(workspace.artifacts);
+    error("Failed to reload workspace");
+    process.exit(1);
+  }
+
+  const updated = syncVersionsToManifest(updatedWorkspace.artifacts);
+  syncSpin.stop();
+
+  if (updated > 0) {
+    success(`Updated ${updated} grekt.yaml file(s)`);
+  } else {
+    info("No version changes detected");
+  }
+
+  // Step 4: Cleanup
+  const cleanSpin = spinner("Cleaning up...");
+  cleanSpin.start();
+  cleanPackageJsonFiles(workspace.artifacts);
+  cleanSpin.stop();
+  success("Removed temporary package.json files");
+
+  log("");
+  success("Version update complete");
+}
 
 /**
  * Find all directories containing grekt.yaml

--- a/src/commands/workspace/index.ts
+++ b/src/commands/workspace/index.ts
@@ -1,0 +1,8 @@
+export {
+  workspaceCommand,
+  loadWorkspace,
+  generatePackageJsonFiles,
+  syncVersionsToManifest,
+  cleanPackageJsonFiles,
+  type WorkspaceData,
+} from "./workspace";

--- a/src/commands/workspace/workspace.ts
+++ b/src/commands/workspace/workspace.ts
@@ -1,0 +1,149 @@
+import { Command } from "commander";
+import { join } from "path";
+import fg from "fast-glob";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+import {
+  parseWorkspaceConfig,
+  isWorkspaceRoot,
+  discoverWorkspaceArtifacts,
+  type WorkspaceArtifact,
+} from "@grekt-labs/cli-engine";
+import { fs } from "#/context";
+import { success, error, info, log, colors } from "#/shared/ui/ui";
+
+const WORKSPACE_CONFIG_FILE = "grekt-workspace.yaml";
+const ARTIFACT_MANIFEST_FILE = "grekt.yaml";
+
+interface WorkspaceData {
+  root: string;
+  artifacts: WorkspaceArtifact[];
+}
+
+/**
+ * Load workspace configuration and discover artifacts.
+ */
+async function loadWorkspace(cwd: string): Promise<WorkspaceData | null> {
+  if (!isWorkspaceRoot(fs, cwd)) {
+    return null;
+  }
+
+  const configPath = join(cwd, WORKSPACE_CONFIG_FILE);
+  const configContent = fs.readFile(configPath);
+  const config = parseWorkspaceConfig(configContent);
+
+  const artifactPaths: string[] = [];
+
+  for (const pattern of config.workspaces) {
+    const matches = await fg(pattern, {
+      cwd,
+      onlyDirectories: true,
+      absolute: true,
+    });
+
+    for (const fullPath of matches) {
+      const manifestPath = join(fullPath, ARTIFACT_MANIFEST_FILE);
+      if (fs.exists(manifestPath)) {
+        artifactPaths.push(fullPath);
+      }
+    }
+  }
+
+  const result = discoverWorkspaceArtifacts(fs, cwd, artifactPaths);
+
+  return {
+    root: result.root,
+    artifacts: result.artifacts,
+  };
+}
+
+/**
+ * Generate temporary package.json files for changeset compatibility.
+ */
+function generatePackageJsonFiles(artifacts: WorkspaceArtifact[]): void {
+  for (const artifact of artifacts) {
+    const packageJsonPath = join(artifact.path, "package.json");
+    const packageJson = {
+      name: artifact.manifest.name,
+      version: artifact.manifest.version,
+      private: true,
+    };
+    fs.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2) + "\n");
+  }
+}
+
+/**
+ * Sync versions from package.json back to grekt.yaml.
+ */
+function syncVersionsToManifest(artifacts: WorkspaceArtifact[]): number {
+  let updated = 0;
+
+  for (const artifact of artifacts) {
+    const packageJsonPath = join(artifact.path, "package.json");
+    const manifestPath = join(artifact.path, ARTIFACT_MANIFEST_FILE);
+
+    if (!fs.exists(packageJsonPath)) continue;
+
+    const packageJson = JSON.parse(fs.readFile(packageJsonPath));
+    const newVersion = packageJson.version;
+
+    if (newVersion && newVersion !== artifact.manifest.version) {
+      const manifestContent = fs.readFile(manifestPath);
+      const manifest = parseYaml(manifestContent);
+      manifest.version = newVersion;
+      fs.writeFile(manifestPath, stringifyYaml(manifest));
+      updated++;
+    }
+  }
+
+  return updated;
+}
+
+/**
+ * Remove generated package.json files.
+ */
+function cleanPackageJsonFiles(artifacts: WorkspaceArtifact[]): void {
+  for (const artifact of artifacts) {
+    const packageJsonPath = join(artifact.path, "package.json");
+    if (fs.exists(packageJsonPath)) {
+      fs.unlink(packageJsonPath);
+    }
+  }
+}
+
+// List subcommand
+const listSubcommand = new Command("list")
+  .description("List all artifacts in the workspace")
+  .action(async () => {
+    const cwd = process.cwd();
+    const workspace = await loadWorkspace(cwd);
+
+    if (!workspace) {
+      error(`No ${WORKSPACE_CONFIG_FILE} found in current directory`);
+      process.exit(1);
+    }
+
+    if (workspace.artifacts.length === 0) {
+      info("No artifacts found in workspace");
+      return;
+    }
+
+    log("");
+    info(`Found ${workspace.artifacts.length} artifact(s) in workspace:`);
+    log("");
+
+    for (const artifact of workspace.artifacts) {
+      log(`  ${colors.bold(artifact.manifest.name)} ${colors.dim(`v${artifact.manifest.version}`)}`);
+      log(`    ${colors.dim(artifact.relativePath)}`);
+    }
+
+    log("");
+  });
+
+// Main workspace command
+export const workspaceCommand = new Command("workspace")
+  .description("Manage monorepo workspaces")
+  .addCommand(listSubcommand);
+
+// Export utilities for use by other commands
+export { loadWorkspace, generatePackageJsonFiles, syncVersionsToManifest, cleanPackageJsonFiles };
+export type { WorkspaceData };

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { infoCommand } from "#/commands/info";
 import { versionsCommand } from "#/commands/versions";
 import { outdatedCommand } from "#/commands/outdated";
 import { versionCommand } from "#/commands/version";
+import { workspaceCommand } from "#/commands/workspace";
 import { loginCommand } from "#/commands/login";
 import { logoutCommand } from "#/commands/logout";
 import { whoamiCommand } from "#/commands/whoami";
@@ -63,6 +64,9 @@ program.addCommand(outdatedCommand);
 
 // Authoring commands
 program.addCommand(versionCommand);
+
+// Workspace commands
+program.addCommand(workspaceCommand);
 
 setupUpdateCheck(pkg.version);
 


### PR DESCRIPTION
## Summary

- Add `grekt workspace list` command to list artifacts in a workspace
- Add `--exec` flag to `grekt version` for external versioning tools (changeset, etc.)
- Add `--changed` flag to `grekt publish` to publish only artifacts where local version > registry
- Add `--dry-run` flag to `grekt publish` for preview mode

## New Commands

```bash
# List workspace artifacts
grekt workspace list

# Use external versioning tool
grekt version --exec "npx changeset version"

# Publish changed artifacts
grekt publish --changed
grekt publish --changed --dry-run
```

## CI Workflow

```yaml
- run: |
    grekt version --exec "npx changeset version"
    grekt publish --changed
```

## Dependencies

- Requires cli-engine 5.2.0 (workspace module)
- Added fast-glob for pattern matching