### PR TITLE
fix: change rules format from json to md

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "grekt",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.971.0",
-        "@grekt-labs/cli-engine": "^5.2.0",
+        "@grekt-labs/cli-engine": "^5.2.1",
         "@inquirer/prompts": "^7.2.0",
         "@supabase/supabase-js": "^2.91.0",
         "chalk": "^5.4.1",
@@ -124,7 +124,7 @@
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
-    "@grekt-labs/cli-engine": ["@grekt-labs/cli-engine@5.2.0", "https://npm.pkg.github.com/download/@grekt-labs/cli-engine/5.2.0/0ad01315ba657e9472123448d3eda74ab5d6b326", { "dependencies": { "gray-matter": "^4.0.3", "semver": "^7.7.3", "yaml": "^2.6.1", "zod": "^3.24.1" } }, "sha512-upaBuvcgn2P2cy1141OhmBFDvRfblgM6q0a1usqVsykccIF+1NlKxuulZiMSUeLlQ2HZL0DNOzIueOwrmlTHDg=="],
+    "@grekt-labs/cli-engine": ["@grekt-labs/cli-engine@5.2.1", "https://npm.pkg.github.com/download/@grekt-labs/cli-engine/5.2.1/c00b9eb8b305a0ebcd3b38562999c2b8cbbd1d63", { "dependencies": { "gray-matter": "^4.0.3", "semver": "^7.7.3", "yaml": "^2.6.1", "zod": "^3.24.1" } }, "sha512-SFhEZw2YBbIXMmAJlIrzoYpxGWkAewv8YkC6UTc6OU8jC2YDZI1IpsIXP7Fo5pP71Q2PpK8b8EPQ4Sj0N5zadg=="],
 
     "@inquirer/ansi": ["@inquirer/ansi@1.0.2", "", {}, "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="],
 

--- a/docs/artifact-format.md
+++ b/docs/artifact-format.md
@@ -53,7 +53,7 @@ Components are categorized by their `grk-type`. Current categories:
 | `skills` | .md | Reusable capabilities |
 | `commands` | .md | User-invoked actions |
 | `mcps` | .json | MCP server configurations |
-| `rules` | .json | Static rules/configurations |
+| `rules` | .md | Coding guidelines and instructions |
 
 **Categories are extensible.** Defined in `cli-engine/src/categories/categories.ts`. Adding a new category there propagates everywhere.
 
@@ -61,7 +61,7 @@ Components are categorized by their `grk-type`. Current categories:
 
 ### Markdown Components (.md)
 
-For `agents`, `skills`, and `commands`. Use YAML frontmatter with `grk-` prefixed fields:
+For `agents`, `skills`, `commands`, and `rules`. Use YAML frontmatter with `grk-` prefixed fields:
 
 ```markdown
 ---
@@ -75,7 +75,7 @@ Instructions for the AI...
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `grk-type` | Yes | One of: `agents`, `skills`, `commands` |
+| `grk-type` | Yes | One of: `agents`, `skills`, `commands`, `rules` |
 | `grk-name` | Yes | Component name |
 | `grk-description` | Yes | What this component does |
 | `grk-agents` | No | Associate with an agent (for skills/commands) |
@@ -86,7 +86,7 @@ Avoids collisions with other tools that use frontmatter (Jekyll, Hugo, etc.).
 
 ### JSON Components (.json)
 
-For `mcps` and `rules`. Same fields but as JSON properties:
+For `mcps`. Same fields but as JSON properties:
 
 ```json
 {
@@ -186,7 +186,7 @@ Instructions...
 }
 ```
 
-**Problem:** Each category has allowed formats. `agents`, `skills`, `commands` must be `.md`. While `mcps`, `rules` must be `.json`. Using the wrong format causes the file to be marked invalid.
+**Problem:** Each category has allowed formats. `agents`, `skills`, `commands`, `rules` must be `.md`. While `mcps` must be `.json`. Using the wrong format causes the file to be marked invalid.
 
 **Fix:** Check `CATEGORY_CONFIG` in `cli-engine/src/categories/categories.ts` for allowed formats.
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.971.0",
-    "@grekt-labs/cli-engine": "^5.2.0",
+    "@grekt-labs/cli-engine": "^5.2.1",
     "@inquirer/prompts": "^7.2.0",
     "@supabase/supabase-js": "^2.91.0",
     "chalk": "^5.4.1",


### PR DESCRIPTION
## Summary

- Upgrade cli-engine to 5.2.1 (rules format change)
- Update documentation to reflect rules are now `.md` files

## Changes

- `@grekt-labs/cli-engine`: 5.2.0 → 5.2.1
- `docs/artifact-format.md`: Updated category table and examples