### PR TITLE
feat: integrate with public registry via Edge Functions

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -53,7 +53,7 @@ registries:
     type: gitlab
     host: gitlab.mycompany.com
     project: artifacts/registry
-    token: glpat-xxxx  # Or use env var
+    token: gldt-xxxx  # Deploy Token (recommended) or use env var
 
   "@another":
     type: github
@@ -76,6 +76,59 @@ For authentication, tokens are resolved in this order:
 2. **Environment variables**:
    - GitHub: `GITHUB_TOKEN` or `GH_TOKEN`
    - GitLab: `GITLAB_TOKEN` or `GL_TOKEN`
+
+## GitLab Authentication
+
+grekt uses GitLab's Generic Package Registry API, which supports both Deploy Tokens and Personal Access Tokens (PAT).
+
+### Deploy Tokens (Recommended)
+
+Deploy Tokens provide minimum necessary permissions without access to your repository code. This is the recommended authentication method for grekt.
+
+**Create a Deploy Token:** Project Settings → Repository → Deploy tokens
+
+**Required scopes:**
+
+| Operation | Scope |
+|-----------|-------|
+| Download | `read_package_registry` |
+| Publish | `write_package_registry` |
+
+**Example token:** `gldt-xxxxxxxxxxxx`
+
+```yaml
+# .grekt/config.yaml
+registries:
+  "@mycompany":
+    type: gitlab
+    host: gitlab.mycompany.com
+    project: artifacts/registry
+    token: gldt-xxxxxxxxxxxx
+```
+
+### Personal Access Tokens (PAT)
+
+PATs work but require broader permissions than grekt actually needs. GitLab's API design couples the Package Registry with repository permissions, forcing you to grant more access than necessary.
+
+**Required scopes:**
+
+| Operation | Scope |
+|-----------|-------|
+| Download | `read_api` |
+| Publish | `write_repository` |
+
+**Example token:** `glpat-xxxxxxxxxxxx`
+
+### Which one to use?
+
+| Scenario | Recommendation |
+|----------|----------------|
+| Self-hosted GitLab registry | Deploy Token |
+| CI/CD pipelines | Deploy Token |
+| Need API access beyond registry | PAT |
+| Older GitLab versions with issues | PAT (fallback) |
+
+Deploy Tokens are scoped to the project and cannot access repository code, making them safer for artifact-only operations.
 
 ## Architecture
 

--- a/src/auth/session/session.test.ts
+++ b/src/auth/session/session.test.ts
@@ -20,18 +20,17 @@ describe("session", () => {
   });
 
   describe("isSupabaseConfigured", () => {
-    test("returns false when env vars not set", () => {
+    test("returns true with defaults (no env vars needed)", () => {
       delete process.env.GREKT_SUPABASE_URL;
       delete process.env.GREKT_SUPABASE_ANON_KEY;
-      delete process.env.SUPABASE_URL;
-      delete process.env.SUPABASE_ANON_KEY;
 
-      expect(isSupabaseConfigured()).toBe(false);
+      // Now always returns true because we have hardcoded defaults
+      expect(isSupabaseConfigured()).toBe(true);
     });
 
-    test("returns true when GREKT_SUPABASE vars are set", () => {
-      process.env.GREKT_SUPABASE_URL = "https://test.supabase.co";
-      process.env.GREKT_SUPABASE_ANON_KEY = "test-key";
+    test("returns true when GREKT_SUPABASE vars override defaults", () => {
+      process.env.GREKT_SUPABASE_URL = "https://custom.supabase.co";
+      process.env.GREKT_SUPABASE_ANON_KEY = "custom-key";
       expect(isSupabaseConfigured()).toBe(true);
     });
   });

--- a/src/auth/session/session.ts
+++ b/src/auth/session/session.ts
@@ -5,14 +5,19 @@ import {
   clearSession as clearStoredSession,
 } from "#/config/project/project";
 import type { StoredSession } from "@grekt-labs/cli-engine";
+import {
+  SUPABASE_PROJECT_URL,
+  SUPABASE_ANON_KEY as DEFAULT_ANON_KEY,
+} from "#/constants";
 
-// Supabase project config - loaded from environment
+// Supabase project config - defaults to official grekt registry
+// Env vars allow override for development or self-hosted registries
 export function getSupabaseUrl(): string {
-  return process.env.GREKT_SUPABASE_URL || process.env.SUPABASE_URL || "";
+  return process.env.GREKT_SUPABASE_URL || SUPABASE_PROJECT_URL;
 }
 
 export function getSupabaseAnonKey(): string {
-  return process.env.GREKT_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY || "";
+  return process.env.GREKT_SUPABASE_ANON_KEY || DEFAULT_ANON_KEY;
 }
 
 /**
@@ -118,6 +123,3 @@ export async function isAuthenticated(): Promise<boolean> {
 export function clearSession(): void {
   clearStoredSession(_projectRoot);
 }
-
-export const SUPABASE_URL = getSupabaseUrl();
-export const SUPABASE_ANON_KEY = getSupabaseAnonKey();

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -273,6 +273,8 @@ async function publishSingleArtifact(
     tarballPath: tarballResult.path,
     scope: artifact.scope,
     projectRoot,
+    description: artifact.manifest.description,
+    keywords: artifact.manifest.keywords,
   };
 
   if (publisher instanceof S3Publisher && !publisher.hasCredentials()) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,12 @@
 export const REGISTRY_HOST = "registry.grekt.com";
 export const REGISTRY_URL = `https://${REGISTRY_HOST}`;
 
+// Supabase configuration (public, safe to expose)
+// These are the defaults for the official grekt registry
+// Can be overridden via GREKT_SUPABASE_URL and GREKT_SUPABASE_ANON_KEY env vars
+export const SUPABASE_PROJECT_URL = "https://pnykoffibrjhfamqfgzt.supabase.co";
+export const SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InBueWtvZmZpYnJqaGZhbXFmZ3p0Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzAyNDEyMjEsImV4cCI6MjA4NTgxNzIyMX0._13xa56wSXZ6wklygVUraZYY8IA5at1lJqaPvaUoC-s";
+
 // Regex to parse artifact ID: @scope/name or @scope/name@version
 // Strict regex: lowercase alphanumeric with hyphens, must start/end with alphanumeric
 // Breaking change: rejects uppercase or special characters in scope/name

--- a/src/registry/api-client/api-client.test.ts
+++ b/src/registry/api-client/api-client.test.ts
@@ -155,20 +155,25 @@ describe("api-client", () => {
     const { RegistryClient } = await import("./api-client");
     const client = new RegistryClient();
 
-    await expect(client.publish("@org/tool", "1.0.0")).rejects.toThrow("Not authenticated");
+    await expect(client.publish({ artifactId: "@org/tool", version: "1.0.0" })).rejects.toThrow("Not authenticated");
   });
 
   test("publish calls edge function with bearer token", async () => {
     mockSession = { access_token: "token" };
     globalThis.fetch = vi.fn(async () => ({
       ok: true,
-      json: async () => ({ uploadUrl: "https://upload.test" }),
+      json: async () => ({ uploadUrl: "https://upload.test", expiresAt: "2024-01-01T00:05:00Z" }),
     })) as unknown as typeof fetch;
 
     const { RegistryClient } = await import("./api-client");
     const client = new RegistryClient();
 
-    const result = await client.publish("@org/tool", "1.0.0");
+    const result = await client.publish({
+      artifactId: "@org/tool",
+      version: "1.0.0",
+      description: "A test artifact",
+      keywords: ["test", "demo", "example"],
+    });
 
     expect(result.uploadUrl).toBe("https://upload.test");
     expect(globalThis.fetch).toHaveBeenCalledWith(
@@ -182,16 +187,81 @@ describe("api-client", () => {
     );
   });
 
-  test("deprecate throws on error", async () => {
-    mockSupabase = createSupabaseMock({
-      versions: {
-        update: { data: null, error: { message: "fail" } },
-      },
-    });
+  test("deprecate throws when not authenticated", async () => {
+    mockSession = null;
 
     const { RegistryClient } = await import("./api-client");
     const client = new RegistryClient();
 
-    await expect(client.deprecate("@org/tool", "1.0.0", "no")).rejects.toThrow("Failed to deprecate");
+    await expect(client.deprecate("@org/tool", "1.0.0", "no")).rejects.toThrow("Not authenticated");
+  });
+
+  test("deprecate calls edge function with bearer token", async () => {
+    mockSession = { access_token: "token" };
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ success: true }),
+    })) as unknown as typeof fetch;
+
+    const { RegistryClient } = await import("./api-client");
+    const client = new RegistryClient();
+
+    await client.deprecate("@org/tool", "1.0.0", "Use v2");
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://supabase.test/functions/v1/deprecate",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer token",
+        }),
+      })
+    );
+  });
+
+  test("deprecate throws on error response", async () => {
+    mockSession = { access_token: "token" };
+    globalThis.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: "You don't have permission" }),
+    })) as unknown as typeof fetch;
+
+    const { RegistryClient } = await import("./api-client");
+    const client = new RegistryClient();
+
+    await expect(client.deprecate("@org/tool", "1.0.0", "no")).rejects.toThrow("You don't have permission");
+  });
+
+  test("undeprecate throws when not authenticated", async () => {
+    mockSession = null;
+
+    const { RegistryClient } = await import("./api-client");
+    const client = new RegistryClient();
+
+    await expect(client.undeprecate("@org/tool", "1.0.0")).rejects.toThrow("Not authenticated");
+  });
+
+  test("undeprecate calls edge function with bearer token", async () => {
+    mockSession = { access_token: "token" };
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ success: true }),
+    })) as unknown as typeof fetch;
+
+    const { RegistryClient } = await import("./api-client");
+    const client = new RegistryClient();
+
+    await client.undeprecate("@org/tool", "1.0.0");
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://supabase.test/functions/v1/undeprecate",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer token",
+        }),
+      })
+    );
   });
 });

--- a/src/registry/api-client/api-client.ts
+++ b/src/registry/api-client/api-client.ts
@@ -2,9 +2,6 @@ import type { ArtifactMetadata } from "@grekt-labs/cli-engine";
 import { sortVersionsDesc, getHighestVersion, validateTarballContents } from "@grekt-labs/cli-engine";
 import { getSupabaseClient, getSession, getSupabaseUrl } from "#/auth/session/session";
 import { fs, shell, http, cryptoProvider } from "#/context";
-import { REGISTRY_URL } from "#/constants";
-
-
 
 export interface VersionInfo {
   version: string;
@@ -20,8 +17,17 @@ export interface DownloadResult {
   deprecationMessage?: string;
 }
 
+export interface PublishRequest {
+  artifactId: string;
+  version: string;
+  description?: string;
+  keywords?: string[];
+  private?: boolean;
+}
+
 export interface PublishResult {
   uploadUrl: string;
+  expiresAt: string;
 }
 
 export interface WhoamiResult {
@@ -131,35 +137,71 @@ export class RegistryClient {
   }
 
   /**
-   * Download artifact tarball
+   * Download artifact tarball using Edge Function for signed URLs
    */
   async download(artifactId: string, version: string | undefined, targetDir: string): Promise<DownloadResult> {
     try {
-      const metadata = await this.getArtifact(artifactId);
-      if (!metadata) {
-        return { success: false, error: "Artifact not found in registry" };
-      }
-
-      const resolvedVersion = version || metadata.latest;
+      // If no version specified, get latest from metadata
+      let resolvedVersion = version;
       if (!resolvedVersion) {
-        return { success: false, error: "No versions available for this artifact" };
+        const metadata = await this.getArtifact(artifactId);
+        if (!metadata) {
+          return { success: false, error: "Artifact not found in registry" };
+        }
+        resolvedVersion = metadata.latest;
+        if (!resolvedVersion) {
+          return { success: false, error: "No versions available for this artifact" };
+        }
       }
 
-      const tarballUrl = `${REGISTRY_URL}/${artifactId}/${resolvedVersion}.tar.gz`;
-      const deprecationMessage = metadata.deprecated[resolvedVersion];
+      // Build download URL with optional auth
+      const session = await getSession();
+      const downloadUrl = new URL(`${this.edgeFunctionUrl}/download`);
+      downloadUrl.searchParams.set("artifact", artifactId);
+      downloadUrl.searchParams.set("version", resolvedVersion);
 
+      const headers: Record<string, string> = {
+        "Accept": "application/json",
+        "User-Agent": "grekt-cli",
+      };
+
+      if (session) {
+        headers["Authorization"] = `Bearer ${session.access_token}`;
+      }
+
+      // Get signed URL from Edge Function
+      const urlResponse = await http.fetch(downloadUrl.toString(), { headers });
+
+      if (!urlResponse.ok) {
+        const errorData = await urlResponse.json().catch(() => null);
+        if (urlResponse.status === 404) {
+          const code = errorData?.code;
+          if (code === "ARTIFACT_NOT_FOUND") {
+            return { success: false, error: "Artifact not found in registry" };
+          }
+          if (code === "VERSION_NOT_FOUND") {
+            return { success: false, error: `Version ${resolvedVersion} not found` };
+          }
+          if (code === "FILE_NOT_FOUND") {
+            return { success: false, error: "Artifact file not found in storage" };
+          }
+          return { success: false, error: errorData?.error || "Not found" };
+        }
+        if (urlResponse.status === 401 || urlResponse.status === 403) {
+          return { success: false, error: "Access denied (check authentication)" };
+        }
+        return { success: false, error: errorData?.error || `Registry returned ${urlResponse.status}` };
+      }
+
+      const { url: tarballUrl, deprecated } = await urlResponse.json();
+
+      // Download the actual tarball from signed URL
       const response = await http.fetch(tarballUrl, {
         headers: { "User-Agent": "grekt-cli" },
       });
 
       if (!response.ok) {
-        if (response.status === 404) {
-          return { success: false, error: `Version ${resolvedVersion} not found` };
-        }
-        if (response.status === 401 || response.status === 403) {
-          return { success: false, error: "Access denied (check authentication)" };
-        }
-        return { success: false, error: `Registry returned ${response.status}` };
+        return { success: false, error: `Download failed: ${response.status}` };
       }
 
       const buffer = await response.arrayBuffer();
@@ -182,7 +224,7 @@ export class RegistryClient {
         success: true,
         version: resolvedVersion,
         resolved: tarballUrl,
-        deprecationMessage,
+        deprecationMessage: deprecated || undefined,
       };
     } catch (err) {
       const message = err instanceof Error ? err.message : "Unknown error";
@@ -236,7 +278,7 @@ export class RegistryClient {
   /**
    * Request upload URL for publishing (calls Edge Function)
    */
-  async publish(artifactId: string, version: string): Promise<PublishResult> {
+  async publish(request: PublishRequest): Promise<PublishResult> {
     const session = await getSession();
     if (!session) {
       throw new Error("Not authenticated");
@@ -248,48 +290,63 @@ export class RegistryClient {
         "Content-Type": "application/json",
         "Authorization": `Bearer ${session.access_token}`,
       },
-      body: JSON.stringify({ artifactId, version }),
+      body: JSON.stringify(request),
     });
 
     if (!response.ok) {
-      const error = await response.text();
-      throw new Error(error || `Failed to get upload URL: ${response.status}`);
+      const errorData = await response.json().catch(() => null);
+      const errorMessage = errorData?.error || `Failed to get upload URL: ${response.status}`;
+      throw new Error(errorMessage);
     }
 
     return await response.json();
   }
 
   /**
-   * Deprecate a version (direct Supabase update, RLS checks ownership)
+   * Deprecate a version (calls Edge Function for ownership validation)
    */
   async deprecate(artifactId: string, version: string, message: string): Promise<void> {
-    const supabase = getSupabaseClient();
+    const session = await getSession();
+    if (!session) {
+      throw new Error("Not authenticated");
+    }
 
-    const { error } = await supabase
-      .from("versions")
-      .update({ deprecated_message: message })
-      .eq("artifact_id", artifactId)
-      .eq("version", version);
+    const response = await http.fetch(`${this.edgeFunctionUrl}/deprecate`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${session.access_token}`,
+      },
+      body: JSON.stringify({ artifactId, version, message }),
+    });
 
-    if (error) {
-      throw new Error(`Failed to deprecate: ${error.message}`);
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => null);
+      throw new Error(errorData?.error || `Failed to deprecate: ${response.status}`);
     }
   }
 
   /**
-   * Remove deprecation from a version (direct Supabase update, RLS checks ownership)
+   * Remove deprecation from a version (calls Edge Function for ownership validation)
    */
   async undeprecate(artifactId: string, version: string): Promise<void> {
-    const supabase = getSupabaseClient();
+    const session = await getSession();
+    if (!session) {
+      throw new Error("Not authenticated");
+    }
 
-    const { error } = await supabase
-      .from("versions")
-      .update({ deprecated_message: null })
-      .eq("artifact_id", artifactId)
-      .eq("version", version);
+    const response = await http.fetch(`${this.edgeFunctionUrl}/undeprecate`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${session.access_token}`,
+      },
+      body: JSON.stringify({ artifactId, version }),
+    });
 
-    if (error) {
-      throw new Error(`Failed to undeprecate: ${error.message}`);
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => null);
+      throw new Error(errorData?.error || `Failed to undeprecate: ${response.status}`);
     }
   }
 }

--- a/src/registry/publishers/api-publisher.ts
+++ b/src/registry/publishers/api-publisher.ts
@@ -36,7 +36,13 @@ export class ApiPublisher implements Publisher {
     const client = createRegistryClient();
 
     try {
-      const { uploadUrl } = await client.publish(ctx.artifactId, ctx.version);
+      const { uploadUrl } = await client.publish({
+        artifactId: ctx.artifactId,
+        version: ctx.version,
+        description: ctx.description,
+        keywords: ctx.keywords,
+        private: ctx.isPrivate,
+      });
 
       // Upload tarball to signed URL
       const fileBuffer = fs.readFileBinary(ctx.tarballPath);

--- a/src/registry/publishers/publisher.types.ts
+++ b/src/registry/publishers/publisher.types.ts
@@ -16,6 +16,9 @@ export interface PublishContext {
   tarballPath: string;
   scope: string;
   projectRoot: string;
+  description?: string;
+  keywords?: string[];
+  isPrivate?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add hardcoded Supabase defaults for official grekt registry (no env vars needed for users)
- Migrate `deprecate`/`undeprecate` from direct Supabase calls to Edge Functions (proper ownership validation)
- Download artifacts via Edge Function for signed URLs (enables private artifact support)
- Pass `description`/`keywords` to publish endpoint for registry metadata
- Add GitLab Deploy Token documentation (recommended over PATs)

## Test plan
- [x] Tests pass (229 tests)
- [ ] Test `grekt login` with official registry
- [ ] Test `grekt publish` with new metadata fields
- [ ] Test `grekt add` for private artifacts