### PR TITLE
fix: validate manifest fields before version bump

### DIFF
--- a/src/commands/version.test.ts
+++ b/src/commands/version.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect } from "bun:test";
+import { ProjectConfigSchema, hasManifestFields } from "@grekt-labs/cli-engine";
 
 describe("version", () => {
   test("module can be imported", async () => {
@@ -18,6 +19,48 @@ describe("version", () => {
     const options = versionCommand.options;
     const dryRunOption = options.find(opt => opt.long === "--dry-run");
     expect(dryRunOption).toBeDefined();
+  });
+
+  describe("manifest validation", () => {
+    test("ProjectConfigSchema parses config without manifest fields", () => {
+      const projectConfig = {
+        targets: ["claude"],
+        artifacts: { "@scope/tool": "1.0.0" },
+      };
+
+      const result = ProjectConfigSchema.safeParse(projectConfig);
+      expect(result.success).toBe(true);
+    });
+
+    test("hasManifestFields returns false for project config", () => {
+      const projectConfig = ProjectConfigSchema.parse({
+        targets: ["claude"],
+        artifacts: { "@scope/tool": "1.0.0" },
+      });
+
+      expect(hasManifestFields(projectConfig)).toBe(false);
+    });
+
+    test("hasManifestFields returns true for artifact manifest", () => {
+      const artifactManifest = ProjectConfigSchema.parse({
+        name: "@scope/my-artifact",
+        version: "1.0.0",
+        description: "My artifact",
+        keywords: ["test"],
+      });
+
+      expect(hasManifestFields(artifactManifest)).toBe(true);
+    });
+
+    test("hasManifestFields returns false when keywords are missing", () => {
+      const incompleteManifest = ProjectConfigSchema.parse({
+        name: "@scope/my-artifact",
+        version: "1.0.0",
+        description: "My artifact",
+      });
+
+      expect(hasManifestFields(incompleteManifest)).toBe(false);
+    });
   });
 
   // Integration test scenarios (require git repo with conventional commits):

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -4,7 +4,8 @@ import { spawnSync } from "child_process";
 import { fs } from "#/context";
 import { parse as parseYaml } from "yaml";
 import {
-  ArtifactManifestSchema,
+  ProjectConfigSchema,
+  hasManifestFields,
   parseName,
   bumpVersion,
   bumpPrerelease,
@@ -105,14 +106,22 @@ export const versionCommand = new Command("version")
       const manifestPath = join(artifactPath, MANIFEST_FILE);
       const manifestContent = fs.readFile(manifestPath);
       const parsed = parseYaml(manifestContent);
-      const manifest = ArtifactManifestSchema.parse(parsed);
-      const { artifactId } = parseName(manifest.name);
+      const config = ProjectConfigSchema.parse(parsed);
+
+      if (!hasManifestFields(config)) {
+        error(`Cannot bump version: ${manifestPath}`);
+        info("Missing required fields: name, version, description");
+        info("This grekt.yaml is not a publishable artifact");
+        process.exit(1);
+      }
+
+      const { artifactId } = parseName(config.name);
 
       const newVersion = bump === "prerelease"
-        ? bumpPrerelease(manifest.version, PRERELEASE_IDENTIFIER)
-        : bumpVersion(manifest.version, bump);
+        ? bumpPrerelease(config.version, PRERELEASE_IDENTIFIER)
+        : bumpVersion(config.version, bump);
 
-      log(`  ${artifactId}: ${manifest.version} → ${newVersion}`);
+      log(`  ${artifactId}: ${config.version} → ${newVersion}`);
 
       if (!options.dryRun) {
         const updatedContent = manifestContent.replace(


### PR DESCRIPTION
## Summary
- Use `ProjectConfigSchema` (optional fields) instead of `ArtifactManifestSchema` (required fields)
- Check with `hasManifestFields()` before attempting version bump
- Show clear error message instead of cryptic ZodError stack trace

## Problem
Running `grekt version major path/to/project` on a directory with a `grekt.yaml` that lacks `name`, `version`, or `description` threw an ugly ZodError.

## Solution
Validate gracefully and show a helpful message:
```
✘ Cannot bump version: path/to/project/grekt.yaml
i Missing required fields: name, version, description
i This grekt.yaml is not a publishable artifact
```

## Test plan
- [x] Tests pass (229 tests)
- [x] Added unit tests for manifest validation logic