### PR TITLE
feat: use friendly-errors for human-readable parsing errors

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "grekt",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.971.0",
-        "@grekt-labs/cli-engine": "^5.2.1",
+        "@grekt-labs/cli-engine": "^5.3.0",
         "@inquirer/prompts": "^7.2.0",
         "@supabase/supabase-js": "^2.91.0",
         "chalk": "^5.4.1",
@@ -124,7 +124,7 @@
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
-    "@grekt-labs/cli-engine": ["@grekt-labs/cli-engine@5.2.1", "https://npm.pkg.github.com/download/@grekt-labs/cli-engine/5.2.1/c00b9eb8b305a0ebcd3b38562999c2b8cbbd1d63", { "dependencies": { "gray-matter": "^4.0.3", "semver": "^7.7.3", "yaml": "^2.6.1", "zod": "^3.24.1" } }, "sha512-SFhEZw2YBbIXMmAJlIrzoYpxGWkAewv8YkC6UTc6OU8jC2YDZI1IpsIXP7Fo5pP71Q2PpK8b8EPQ4Sj0N5zadg=="],
+    "@grekt-labs/cli-engine": ["@grekt-labs/cli-engine@5.3.0", "https://npm.pkg.github.com/download/@grekt-labs/cli-engine/5.3.0/d893552bb7644151e73df2899b5539ef63f57818", { "dependencies": { "gray-matter": "^4.0.3", "semver": "^7.7.3", "yaml": "^2.6.1", "zod": "^3.24.1" } }, "sha512-j1LCRmLz3S74PBsZ1M+txMNRwjxxYrSRB+QKei4TZogckOYn+k5Ygpx/VH5qNa1gz+OAxKs0NdIJpKSkuAKi2Q=="],
 
     "@inquirer/ansi": ["@inquirer/ansi@1.0.2", "", {}, "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="],
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.971.0",
-    "@grekt-labs/cli-engine": "^5.2.1",
+    "@grekt-labs/cli-engine": "^5.3.0",
     "@inquirer/prompts": "^7.2.0",
     "@supabase/supabase-js": "^2.91.0",
     "chalk": "^5.4.1",

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -2,9 +2,9 @@ import { Command } from "commander";
 import { join, resolve } from "path";
 import { spawnSync } from "child_process";
 import { fs } from "#/context";
-import { parse as parseYaml } from "yaml";
 import {
   ProjectConfigSchema,
+  safeParseYaml,
   hasManifestFields,
   parseName,
   bumpVersion,
@@ -105,8 +105,15 @@ export const versionCommand = new Command("version")
     for (const artifactPath of artifactPaths) {
       const manifestPath = join(artifactPath, MANIFEST_FILE);
       const manifestContent = fs.readFile(manifestPath);
-      const parsed = parseYaml(manifestContent);
-      const config = ProjectConfigSchema.parse(parsed);
+      const result = safeParseYaml(manifestContent, ProjectConfigSchema, manifestPath);
+
+      if (!result.success) {
+        error(result.error.message);
+        result.error.details?.forEach((detail) => info(`  ${detail}`));
+        process.exit(1);
+      }
+
+      const config = result.data;
 
       if (!hasManifestFields(config)) {
         error(`Cannot bump version: ${manifestPath}`);

--- a/src/commands/workspace/workspace.ts
+++ b/src/commands/workspace/workspace.ts
@@ -29,8 +29,15 @@ async function loadWorkspace(cwd: string): Promise<WorkspaceData | null> {
 
   const configPath = join(cwd, WORKSPACE_CONFIG_FILE);
   const configContent = fs.readFile(configPath);
-  const config = parseWorkspaceConfig(configContent);
+  const result = parseWorkspaceConfig(configContent, configPath);
 
+  if (!result.success) {
+    error(result.error.message);
+    result.error.details?.forEach((detail) => info(`  ${detail}`));
+    process.exit(1);
+  }
+
+  const config = result.data;
   const artifactPaths: string[] = [];
 
   for (const pattern of config.workspaces) {
@@ -48,11 +55,11 @@ async function loadWorkspace(cwd: string): Promise<WorkspaceData | null> {
     }
   }
 
-  const result = discoverWorkspaceArtifacts(fs, cwd, artifactPaths);
+  const discovered = discoverWorkspaceArtifacts(fs, cwd, artifactPaths);
 
   return {
-    root: result.root,
-    artifacts: result.artifacts,
+    root: discovered.root,
+    artifacts: discovered.artifacts,
   };
 }
 

--- a/src/config/project/project.ts
+++ b/src/config/project/project.ts
@@ -1,9 +1,10 @@
 import { dirname, resolve } from "path";
-import { parse, stringify } from "yaml";
+import { stringify } from "yaml";
 import { fs } from "#/context";
 import {
   ProjectConfigSchema,
   LocalConfigSchema,
+  safeParseYaml,
   type ProjectConfig,
   type LocalConfig,
   type StoredSession,
@@ -23,18 +24,6 @@ function ensureDir(filepath: string): void {
   }
 }
 
-function readYaml<T>(filepath: string, defaultValue: T): T {
-  if (!fs.exists(filepath)) {
-    return defaultValue;
-  }
-  const content = fs.readFile(filepath);
-  const parsed = parse(content);
-  if (parsed === null || parsed === undefined) {
-    return defaultValue;
-  }
-  return parsed as T;
-}
-
 function writeYaml(filepath: string, data: unknown, secure = false): void {
   ensureDir(filepath);
   const content = stringify(data);
@@ -47,8 +36,22 @@ function writeYaml(filepath: string, data: unknown, secure = false): void {
 // Project config (grekt.yaml)
 export function getConfig(projectRoot: string = process.cwd()): ProjectConfig {
   const filepath = `${projectRoot}/${GREKT_YAML}`;
-  const raw = readYaml(filepath, {});
-  return ProjectConfigSchema.parse(raw);
+  if (!fs.exists(filepath)) {
+    // Return empty config if file doesn't exist (will be validated by schema)
+    const result = safeParseYaml("{}", ProjectConfigSchema, filepath);
+    if (!result.success) {
+      const details = result.error.details?.join("\n  ") ?? "";
+      throw new Error(`${result.error.message}${details ? `\n  ${details}` : ""}`);
+    }
+    return result.data;
+  }
+  const content = fs.readFile(filepath);
+  const result = safeParseYaml(content, ProjectConfigSchema, filepath);
+  if (!result.success) {
+    const details = result.error.details?.join("\n  ") ?? "";
+    throw new Error(`${result.error.message}${details ? `\n  ${details}` : ""}`);
+  }
+  return result.data;
 }
 
 export function saveConfig(config: ProjectConfig, projectRoot: string = process.cwd()): void {
@@ -93,8 +96,13 @@ export function getLocalConfig(projectRoot: string = process.cwd()): LocalConfig
   if (!filepath) {
     return null;
   }
-  const raw = readYaml(filepath, {});
-  return LocalConfigSchema.parse(raw);
+  const content = fs.readFile(filepath);
+  const result = safeParseYaml(content, LocalConfigSchema, filepath);
+  if (!result.success) {
+    const details = result.error.details?.join("\n  ") ?? "";
+    throw new Error(`${result.error.message}${details ? `\n  ${details}` : ""}`);
+  }
+  return result.data;
 }
 
 export function saveLocalConfig(config: LocalConfig, projectRoot: string = process.cwd()): void {

--- a/src/context/engine.ts
+++ b/src/context/engine.ts
@@ -19,7 +19,12 @@ import { LOCKFILE } from "#/config/paths/paths";
 // Lockfile operations
 export function getLockfile(projectRoot: string = process.cwd()): Lockfile {
   const lockfilePath = `${projectRoot}/${LOCKFILE}`;
-  return _getLockfile(fs, lockfilePath);
+  const result = _getLockfile(fs, lockfilePath);
+  if (!result.success) {
+    const details = result.error.details?.join("\n  ") ?? "";
+    throw new Error(`${result.error.message}${details ? `\n  ${details}` : ""}`);
+  }
+  return result.data;
 }
 
 export function saveLockfile(data: Lockfile, projectRoot: string = process.cwd()): void {


### PR DESCRIPTION
## Summary
- Use `safeParseYaml` from cli-engine for config parsing
- Errors now show friendly messages instead of raw Zod/YAML stack traces

## Changes
- `config/project/project.ts`: getConfig, getLocalConfig
- `commands/version.ts`: manifest parsing
- `commands/workspace/workspace.ts`: workspace config parsing  
- `context/engine.ts`: getLockfile wrapper
- Bump cli-engine to latest

## Error Output Examples

**Before:**
```
YAMLParseError: Nested mappings are not allowed in compact mappings at line 4, column 14
    at <anonymous> (/$bunfs/root/grekt-macos-arm64:6677:28)
    at resolveBlockMap ...
```

**After:**
```
Invalid YAML syntax in grekt.yaml
  Nested mappings are not allowed in compact mappings at line 4, column 14
```

## Test plan
- [x] All 229 tests pass
- [x] Build succeeds