### PR TITLE
fix: add global error handler for cleaner error output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,5 +70,11 @@ program.addCommand(workspaceCommand);
 
 setupUpdateCheck(pkg.version);
 
-await program.parseAsync();
-refreshUpdateCache();
+try {
+  await program.parseAsync();
+  refreshUpdateCache();
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`\n${colors.red("error:")} ${message}\n`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- Add try-catch around program.parseAsync() to catch unhandled exceptions
- Display only the error message, not the full stack trace
- Exit with code 1 on error

## Test plan
- [x] Build succeeds
- [x] All tests pass