### PR TITLE
fix(deps): bump cli-engine to 5.3.4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "grekt",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.971.0",
-        "@grekt-labs/cli-engine": "5.3.3",
+        "@grekt-labs/cli-engine": "^5.3.4",
         "@inquirer/prompts": "^7.2.0",
         "@supabase/supabase-js": "^2.91.0",
         "chalk": "^5.4.1",
@@ -124,7 +124,7 @@
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
-    "@grekt-labs/cli-engine": ["@grekt-labs/cli-engine@5.3.3", "https://npm.pkg.github.com/download/@grekt-labs/cli-engine/5.3.3/04c513833569a421902caffada51b311e5f90c1a", { "dependencies": { "gray-matter": "^4.0.3", "semver": "^7.7.3", "yaml": "^2.6.1", "zod": "^3.24.1" } }, "sha512-Z6q74WiYWOWWWL/+4+wZJpw88c0u5dZ2SUxshm04hZFwejr0usTWus9d8100weCSG/E2JtXbwe78obnZ26DorQ=="],
+    "@grekt-labs/cli-engine": ["@grekt-labs/cli-engine@5.3.4", "https://npm.pkg.github.com/download/@grekt-labs/cli-engine/5.3.4/fe462567f1bcc832d795eb35f40bd0c78c9ad05e", { "dependencies": { "gray-matter": "^4.0.3", "semver": "^7.7.3", "yaml": "^2.6.1", "zod": "^3.24.1" } }, "sha512-z3Ztln5SxyjZYm7+53dzoo447zimPmDS5gwHQVq3C1A2ZuyPiaR6cRTuGvAyWbtdANFaUC39YSzE5ix8uIYb4A=="],
 
     "@inquirer/ansi": ["@inquirer/ansi@1.0.2", "", {}, "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="],
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.971.0",
-    "@grekt-labs/cli-engine": "5.3.3",
+    "@grekt-labs/cli-engine": "^5.3.4",
     "@inquirer/prompts": "^7.2.0",
     "@supabase/supabase-js": "^2.91.0",
     "chalk": "^5.4.1",


### PR DESCRIPTION
## Summary
- Update @grekt-labs/cli-engine from 5.3.3 to 5.3.4
- Fixes GitLab Deploy Token support by using URL-encoded project path directly

## Test plan
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)