### PR TITLE
chore(deps): bump cli-engine to 5.5.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "grekt",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.971.0",
-        "@grekt-labs/cli-engine": "^5.3.4",
+        "@grekt-labs/cli-engine": "^5.5.0",
         "@inquirer/prompts": "^7.2.0",
         "@supabase/supabase-js": "^2.91.0",
         "chalk": "^5.4.1",
@@ -124,7 +124,7 @@
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
-    "@grekt-labs/cli-engine": ["@grekt-labs/cli-engine@5.3.4", "https://npm.pkg.github.com/download/@grekt-labs/cli-engine/5.3.4/fe462567f1bcc832d795eb35f40bd0c78c9ad05e", { "dependencies": { "gray-matter": "^4.0.3", "semver": "^7.7.3", "yaml": "^2.6.1", "zod": "^3.24.1" } }, "sha512-z3Ztln5SxyjZYm7+53dzoo447zimPmDS5gwHQVq3C1A2ZuyPiaR6cRTuGvAyWbtdANFaUC39YSzE5ix8uIYb4A=="],
+    "@grekt-labs/cli-engine": ["@grekt-labs/cli-engine@5.5.0", "https://npm.pkg.github.com/download/@grekt-labs/cli-engine/5.5.0/8434fb31a2aa07fe8bdf43d59a146083fcef088b", { "dependencies": { "gray-matter": "^4.0.3", "semver": "^7.7.3", "yaml": "^2.6.1", "zod": "^3.24.1" } }, "sha512-24+vTh9U38mcZSAPGrx31yUS830o63ZPnvNBOEpLY5EtIn9am8KytvTtxkOAGb5qbaivU+7LEh4w+6WrTq+hqQ=="],
 
     "@inquirer/ansi": ["@inquirer/ansi@1.0.2", "", {}, "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="],
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.971.0",
-    "@grekt-labs/cli-engine": "^5.3.4",
+    "@grekt-labs/cli-engine": "^5.5.0",
     "@inquirer/prompts": "^7.2.0",
     "@supabase/supabase-js": "^2.91.0",
     "chalk": "^5.4.1",


### PR DESCRIPTION
## Summary
- Bump @grekt-labs/cli-engine from 5.3.4 to 5.5.0

## Included features
- `folder` config for GitLab registry (monorepo organization)
- `folder` config for GitHub GHCR (monorepo organization)

## Test plan
- [x] All 229 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)