### PR TITLE
fix: rename folder to prefix in registry config

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "grekt",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.971.0",
-        "@grekt-labs/cli-engine": "^5.5.1",
+        "@grekt-labs/cli-engine": "^5.5.2",
         "@inquirer/prompts": "^7.2.0",
         "@supabase/supabase-js": "^2.91.0",
         "chalk": "^5.4.1",
@@ -124,7 +124,7 @@
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
-    "@grekt-labs/cli-engine": ["@grekt-labs/cli-engine@5.5.1", "https://npm.pkg.github.com/download/@grekt-labs/cli-engine/5.5.1/54cbbbcc642f610ebab9b97b86edfa4f9c170aae", { "dependencies": { "gray-matter": "^4.0.3", "semver": "^7.7.3", "yaml": "^2.6.1", "zod": "^3.24.1" } }, "sha512-yxTNrYIHB5cYLX/JclfnmAYzHecOxnCfZMXyS6swcPO4jj4QOezuT7NyYbw6aUTBazQYhaRWcM1MkSfDhGIFZQ=="],
+    "@grekt-labs/cli-engine": ["@grekt-labs/cli-engine@5.5.2", "https://npm.pkg.github.com/download/@grekt-labs/cli-engine/5.5.2/9112ec5a2414508b8df0c8d3f67f0767e784ca05", { "dependencies": { "gray-matter": "^4.0.3", "semver": "^7.7.3", "yaml": "^2.6.1", "zod": "^3.24.1" } }, "sha512-HaIuzvRRLKBPZdyE3w/NOT8S5MHpn0TafdeoQ9o+lKdcEdSBRMCwzHEl5DzMk9rLLuuklGK53uWsAXr6Rl6g+g=="],
 
     "@inquirer/ansi": ["@inquirer/ansi@1.0.2", "", {}, "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="],
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.971.0",
-    "@grekt-labs/cli-engine": "^5.5.1",
+    "@grekt-labs/cli-engine": "^5.5.2",
     "@inquirer/prompts": "^7.2.0",
     "@supabase/supabase-js": "^2.91.0",
     "chalk": "^5.4.1",

--- a/src/registry/registry.types.ts
+++ b/src/registry/registry.types.ts
@@ -17,7 +17,7 @@ export interface ResolvedRegistry {
   host: string;
   project?: string;
   token?: string;
-  folder?: string;
+  prefix?: string;
 }
 
 /**
@@ -86,7 +86,7 @@ export interface RegistryEntry {
   project?: string;
   host?: string;
   token?: string;
-  folder?: string;
+  prefix?: string;
 }
 
 /**

--- a/src/registry/resolver/resolver.test.ts
+++ b/src/registry/resolver/resolver.test.ts
@@ -134,23 +134,23 @@ describe("resolver", () => {
       expect(result.token).toBe("env-github-token");
     });
 
-    test("includes folder when configured", () => {
+    test("includes prefix when configured", () => {
       const localConfig: LocalConfig = {
         registries: {
           "@myorg": {
             type: "gitlab",
             project: "myorg/artifacts",
-            folder: "frontend",
+            prefix: "frontend",
           },
         },
       };
 
       const result = resolveRegistry("@myorg", localConfig);
 
-      expect(result.folder).toBe("frontend");
+      expect(result.prefix).toBe("frontend");
     });
 
-    test("folder is undefined when not configured", () => {
+    test("prefix is undefined when not configured", () => {
       const localConfig: LocalConfig = {
         registries: {
           "@myorg": {
@@ -162,7 +162,7 @@ describe("resolver", () => {
 
       const result = resolveRegistry("@myorg", localConfig);
 
-      expect(result.folder).toBeUndefined();
+      expect(result.prefix).toBeUndefined();
     });
   });
 

--- a/src/registry/resolver/resolver.ts
+++ b/src/registry/resolver/resolver.ts
@@ -105,7 +105,7 @@ export function resolveRegistry(
     host: entry.host || getDefaultHost(entry.type),
     project: entry.project,
     token,
-    folder: entry.folder,
+    prefix: entry.prefix,
   };
 }
 


### PR DESCRIPTION
## Summary
- Update cli-engine to 5.5.2
- Rename `folder` to `prefix` in registry types and resolver

## Test plan
- [x] All tests pass (231 tests)
- [x] Build passes