### PR TITLE
fix(publish): show login prompt instead of GitLab config

### DIFF
--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -288,7 +288,7 @@ async function publishSingleArtifact(
     const authenticated = await isApiAuthenticated();
     if (!authenticated) {
       removeTarball(tarballResult.path);
-      showRegistryConfigHelp(artifact.scope, projectRoot);
+      error("Not logged in. Run 'grekt login' first to publish to the default registry.");
       throw new Error("Not authenticated");
     }
   }


### PR DESCRIPTION
## Summary
- When publishing to the default registry without being logged in, the error incorrectly showed GitLab registry configuration instructions instead of prompting the user to run `grekt login`

## Test plan
- [ ] Run `grekt publish` on a `@grekt` scoped artifact without being logged in
- [ ] Verify it shows "Not logged in. Run 'grekt login' first" instead of GitLab YAML config
- [ ] Verify custom scope without config still shows `showRegistryConfigHelp` correctly