### PR TITLE
feat: add publish-confirm call after upload

### DIFF
--- a/src/registry/api-client/api-client.ts
+++ b/src/registry/api-client/api-client.ts
@@ -357,6 +357,31 @@ export class RegistryClient {
       throw new Error(errorData?.error || `Failed to undeprecate: ${response.status}`);
     }
   }
+
+  /**
+   * Confirm publish and trigger tarball extraction (calls Edge Function)
+   * This extracts the tarball contents for file browsing in the web UI.
+   */
+  async confirmPublish(artifactId: string, version: string): Promise<void> {
+    const session = await getSession();
+    if (!session) {
+      throw new Error("Not authenticated");
+    }
+
+    const response = await http.fetch(`${this.edgeFunctionUrl}/publish-confirm`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${session.access_token}`,
+      },
+      body: JSON.stringify({ artifactId, version }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => null);
+      throw new Error(errorData?.error || `Failed to confirm publish: ${response.status}`);
+    }
+  }
 }
 
 /**

--- a/src/registry/publishers/api-publisher.ts
+++ b/src/registry/publishers/api-publisher.ts
@@ -73,6 +73,14 @@ export class ApiPublisher implements Publisher {
         };
       }
 
+      // Confirm publish to trigger tarball extraction for file browsing
+      try {
+        await client.confirmPublish(ctx.artifactId, ctx.version);
+      } catch (confirmErr) {
+        // Log but don't fail the publish - extraction is optional for MVP
+        console.error("Warning: Failed to extract files for browsing:", confirmErr);
+      }
+
       return { success: true };
     } catch (err) {
       return {


### PR DESCRIPTION
## Summary

- Adds `confirmPublish` method to RegistryClient
- Calls `/publish-confirm` endpoint after uploading tarball to R2
- Triggers server-side tarball extraction for file browsing in web UI

## Notes

- The confirm call is non-blocking - if it fails, the publish still succeeds
- Extraction is optional for MVP, failure only logs a warning

## Test plan

- [x] `bun test` passes
- [x] `bun run build` succeeds
- [ ] Manual test: publish an artifact and verify files are extracted

🤖 Generated with [Claude Code](https://claude.com/claude-code)